### PR TITLE
Revert "Update dependency chalk to v5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "workbox-cli": "7.0.0"
   },
   "dependencies": {
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.2",
     "commander": "^11.0.0",
     "inquirer": "^8.1.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   chalk:
-    specifier: ^5.0.0
-    version: 5.3.0
+    specifier: ^4.1.2
+    version: 4.1.2
   commander:
     specifier: ^11.0.0
     version: 11.0.0
@@ -3567,11 +3567,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  /chalk@5.3.0:
-    resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
-    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
-    dev: false
 
   /chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}


### PR DESCRIPTION
fix 

> ts-node scripts import library --all

/home/runner/work/TiddlyWiki-CPL/TiddlyWiki-CPL/node_modules/.pnpm/ts-node@10.9.1_@types+node@20.6.3_typescript@5.2.2/node_modules/ts-node/dist/index.js:851
            return old(m, filename);
                   ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /home/runner/work/TiddlyWiki-CPL/TiddlyWiki-CPL/node_modules/.pnpm/chalk@5.3.0/node_modules/chalk/source/index.js from /home/runner/work/TiddlyWiki-CPL/TiddlyWiki-CPL/scripts/index.ts not supported.
Instead change the require of index.js in /home/runner/work/TiddlyWiki-CPL/TiddlyWiki-CPL/scripts/index.ts to a dynamic import() which is available in all CommonJS modules.