### PR TITLE
fix: mirror detection and CPL fallback entry

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -64,6 +64,41 @@ jobs:
           node scripts/fetch-plugins.js --allow-ci --best-effort
           pnpm run build:library
 
+      - name: Ensure root site entry exists
+        run: |
+          if [ ! -f dist/index.html ]; then
+            cat > dist/index.html <<'EOF'
+          <!DOCTYPE html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>TiddlyWiki CPL</title>
+              <style>
+                body { font-family: system-ui, sans-serif; margin: 0; padding: 32px; background: #f8fafc; color: #0f172a; }
+                main { max-width: 760px; margin: 0 auto; background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 10px 30px rgba(15,23,42,.08); }
+                a { color: #2563eb; }
+                .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
+                .actions a { text-decoration: none; padding: 10px 16px; border-radius: 999px; font-weight: 600; }
+                .primary { background: #2563eb; color: #fff; }
+                .secondary { background: #e2e8f0; color: #0f172a; }
+              </style>
+            </head>
+            <body>
+              <main>
+                <p style="margin:0 0 8px; color:#64748b; text-transform:uppercase; letter-spacing:.08em; font-size:.9rem;">TiddlyWiki CPL</p>
+                <h1 style="margin:0 0 12px;">CPL Web UI Fallback</h1>
+                <p style="margin:0; color:#475569;">The main wiki UI was not generated for this deployment, but the CPL mirror repository and client plugin are still available below.</p>
+                <div class="actions">
+                  <a class="primary" href="repo/">Open repo mirror landing page</a>
+                  <a class="secondary" href="repo/plugins/Gk0Wk_CPL-Repo.json">Download CPL client plugin</a>
+                </div>
+              </main>
+            </body>
+          </html>
+          EOF
+          fi
+
     #   - name: Minify Front Page HTML (also check if it exists)
     #     run: pnpm exec html-minifier-terser -c ./html-minifier-terser.config.json -o dist/index.html dist/index.html
     #   - name: Minify Library HTML (also check if it exists)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ Place plugin `.json` files into `wiki/files/plugin-offline/` to make them availa
 
 ### Production Server
 
+For a writable local runtime server that exercises the CPL boot path exactly like the Node.js deployment:
+
+```bash
+pnpm server:test
+```
+
 Start the production server in read-only mode:
 
 ```bash
@@ -116,6 +122,8 @@ pnpm server:prod
 ```
 
 The server launcher compiles the TypeScript plugin sources into runtime plugin JSON files under `cache/runtime-plugins/`, and then starts a standard TiddlyWiki Node.js server with those compiled plugins injected as boot-time plugin arguments. This keeps the runtime compatible with TiddlyWiki's Node.js boot process while preserving TypeScript source under `src/`.
+
+This is intentionally different from `pnpm dev:wiki`: `pnpm dev:wiki` runs the Modern.TiddlyDev development server with wiki writes enabled, while `pnpm server:test` verifies the production-like runtime plugin loading path used by the CPL server.
 
 For public deployments, configure read-only mode so wiki writes stay disabled while download statistics and API routes remain available.
 

--- a/SERVER_README.md
+++ b/SERVER_README.md
@@ -13,6 +13,7 @@ Use README.md for:
 Quick reference:
 
 ```bash
+pnpm server:test    # writable local runtime server
 pnpm server:prod    # read-only server mode
 pnpm test:api
 pnpm test:e2e

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:lan": "tiddlywiki-plugin-dev dev --wiki wiki --lan",
     "dev:wiki": "tiddlywiki-plugin-dev dev --wiki wiki --write-wiki",
     "build": "tiddlywiki-plugin-dev build --wiki wiki",
+    "build:library": "ts-node scripts/build-library.ts",
     "import:libraries": "ts-node scripts/index.ts import library --all",
     "import:official-library": "ts-node scripts/index.ts import library --official",
     "server:test": "node scripts/server.js",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "dev:lan": "tiddlywiki-plugin-dev dev --wiki wiki --lan",
     "dev:wiki": "tiddlywiki-plugin-dev dev --wiki wiki --write-wiki",
     "build": "tiddlywiki-plugin-dev build --wiki wiki",
-    "build:library": "ts-node scripts/build-library.ts",
     "import:libraries": "ts-node scripts/index.ts import library --all",
     "import:official-library": "ts-node scripts/index.ts import library --official",
     "server:test": "node scripts/server.js",

--- a/scripts/build/allplugins.emplate.html
+++ b/scripts/build/allplugins.emplate.html
@@ -274,10 +274,11 @@
       <h1>Static Repo Mirror</h1>
       <p>
         This page is the compatibility bridge used by the CPL client plugin and by older CI-deployed HTML mirrors.
-        It still serves plugin metadata and package files, but it also now provides a direct browser landing page instead of rendering blank.
+            It still serves plugin metadata and package files, but it also now provides a direct browser landing page instead of rendering blank.
       </p>
       <div class="actions">
         <a class="action primary" href="../#Welcome:Welcome">Open CPL Wiki UI</a>
+            <a class="action" href="plugins/Gk0Wk_CPL-Repo.json">Download CPL Client Plugin</a>
         <a class="action" href="index.json">Open plugin index JSON</a>
         <a class="action" href="plugins/">Browse exported plugin files</a>
       </div>
@@ -297,6 +298,7 @@
       </div>
       <p class="note">
         If you are opening this directly in a browser and expected an interactive gallery, use the wiki UI link above.
+        If the main CPL web UI is temporarily unavailable, you can still install the CPL client by dragging <code>plugins/Gk0Wk_CPL-Repo.json</code> into another wiki.
         TiddlyWiki instances should keep pointing their mirror setting at this repo path, for example <code>/repo</code>.
       </p>
     </main>

--- a/scripts/validate-setup.js
+++ b/scripts/validate-setup.js
@@ -56,7 +56,8 @@ const checks = [
     name: 'Package.json scripts updated',
     check: () => {
       const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
-      return pkg.scripts['server:prod'] &&
+      return pkg.scripts['server:test'] &&
+             pkg.scripts['server:prod'] &&
              pkg.scripts['build'] &&
              pkg.scripts['test'];
     }

--- a/src/CPLPlugin/config/defaults.multids
+++ b/src/CPLPlugin/config/defaults.multids
@@ -1,7 +1,9 @@
 title: $:/plugins/Gk0Wk/CPL-Repo/config/
 
 update-filter: [has[plugin-type]] -[prefix[$:/temp/]] -[[$:/core]]
-repos: https://tw-cpl.netlify.app/repo https://tiddly-gittly.github.io/TiddlyWiki-CPL/repo
+repos: https://tw-cpl.netlify.app/repo https://tiddly-gittly.github.io/TiddlyWiki-CPL/repo https://cpl.tidgi.fun/repo
+static-repos: https://tw-cpl.netlify.app/repo https://tiddly-gittly.github.io/TiddlyWiki-CPL/repo
+server-repos: https://cpl.tidgi.fun/repo
 current-repo: https://tw-cpl.netlify.app/repo
 auto-refresh-at-startup: yes
 popup-readme-at-startup-threshold: 1

--- a/src/CPLPlugin/startup/api-client.ts
+++ b/src/CPLPlugin/startup/api-client.ts
@@ -1,5 +1,6 @@
 import { tw, type RootWidgetEvent, type OAuthResponse } from './api-client/types';
 import { MIRROR_CONFIG_TITLE } from './api-client/constants';
+import { getCurrentMirrorOrigin } from './api-client/state';
 import { getEventParam, getViewedPluginTitle } from './api-client/utilities';
 import { setJwtToken } from './api-client/auth';
 import { createCplServerApi } from './api-client/api';
@@ -123,8 +124,12 @@ export const startup = (): void => {
   });
 
   tw.rootWidget.addEventListener('cpl-github-login', (_event: RootWidgetEvent): undefined => {
-    const githubClientId = '';
-    const redirectUri = `${window.location.origin}/cpl/api/auth/github/callback`;
+    const githubClientId = tw.wiki.getTiddlerText('$:/temp/CPL-Server/github-client-id', '');
+    if (!githubClientId) {
+      console.error('[CPL-Server] GitHub client ID not available. Server may not have OAuth configured.');
+      return undefined;
+    }
+    const redirectUri = `${getCurrentMirrorOrigin()}/cpl/api/auth/github/callback`;
     const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${encodeURIComponent(githubClientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:read`;
     window.location.href = githubAuthUrl;
     return undefined;
@@ -134,7 +139,7 @@ export const startup = (): void => {
     const code = new URLSearchParams(window.location.search).get('code');
     if (code) {
       tw.utils.httpRequest({
-        url: `/cpl/api/auth/github/callback?code=${encodeURIComponent(code)}`,
+        url: `${getCurrentMirrorOrigin()}/cpl/api/auth/github/callback?code=${encodeURIComponent(code)}`,
         type: 'GET',
         headers: { 'Content-Type': 'application/json' },
         callback: (error: unknown, response: string) => {

--- a/src/CPLPlugin/startup/api-client/constants.ts
+++ b/src/CPLPlugin/startup/api-client/constants.ts
@@ -3,4 +3,6 @@ export const API_STATUS_TIDDLER = '$:/temp/CPL-Repo/api-status';
 export const API_TYPE_TIDDLER = '$:/temp/CPL-Repo/mirror-type';
 export const API_MESSAGE_TIDDLER = '$:/temp/CPL-Repo/mirror-message';
 export const MIRROR_CONFIG_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/current-repo';
+export const MIRROR_STATIC_REPOS_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/static-repos';
+export const MIRROR_SERVER_REPOS_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/server-repos';
 export const JWT_TOKEN_KEY = 'cpl_jwt_token';

--- a/src/CPLPlugin/startup/api-client/http.ts
+++ b/src/CPLPlugin/startup/api-client/http.ts
@@ -1,11 +1,14 @@
 import { tw, type JsonObject, type ApiCallback } from './types';
-import { CPL_API_BASE } from './constants';
+import { API_MESSAGE_TIDDLER } from './constants';
 import { getErrorMessage } from './utilities';
 import { getJwtToken } from './auth';
-import { apiAvailability } from './state';
+import { apiAvailability, getCurrentMirrorApiBase } from './state';
 
 const getUnavailableMessage = (): string =>
-  'This mirror does not provide CPL server API features.';
+  tw.wiki.getTiddlerText(
+    API_MESSAGE_TIDDLER,
+    'This mirror does not provide CPL server API features.',
+  );
 
 export const rawApiRequest = <T extends JsonObject>(
   method: string,
@@ -13,7 +16,6 @@ export const rawApiRequest = <T extends JsonObject>(
   body: JsonObject | null,
   callback: ApiCallback<T>,
   extraHeaders?: Record<string, string>,
-  baseUrl?: string,
 ): void => {
   const options: {
     url: string;
@@ -22,10 +24,9 @@ export const rawApiRequest = <T extends JsonObject>(
     data?: string;
     callback: (error: unknown, response: string) => void;
   } = {
-    url: baseUrl ? `${baseUrl}${CPL_API_BASE}${endpoint}` : `${CPL_API_BASE}${endpoint}`,
+    url: `${getCurrentMirrorApiBase()}${endpoint}`,
     type: method,
     headers: {
-      'Content-Type': 'application/json',
       ...(extraHeaders ?? {}),
     },
     callback: (error, response) => {
@@ -43,6 +44,7 @@ export const rawApiRequest = <T extends JsonObject>(
   };
 
   if (body) {
+    options.headers['Content-Type'] = 'application/json';
     options.data = JSON.stringify(body);
   }
 

--- a/src/CPLPlugin/startup/api-client/server-status.ts
+++ b/src/CPLPlugin/startup/api-client/server-status.ts
@@ -1,45 +1,76 @@
 import { tw, type CPLServerApi, type JsonObject } from './types';
 import { rawApiRequest } from './http';
 import { setApiStatus, clearServerTempState } from './utilities';
-import { getCurrentMirrorEntry, apiAvailability, lastMirrorEntry, setApiAvailability, setLastMirrorEntry } from './state';
+import {
+  getConfiguredMirrorType,
+  getCurrentMirrorEntry,
+  getMirrorOrigin,
+  apiAvailability,
+  lastMirrorEntry,
+  setApiAvailability,
+  setLastMirrorEntry,
+  type MirrorType,
+} from './state';
 
-const getMirrorBaseUrl = (): string | undefined => {
+const setAnonymousUserStatus = (): void => {
+  tw.wiki.addTiddler({
+    title: '$:/temp/CPL-Server/user-status',
+    text: 'anonymous',
+  });
+};
+
+const getMirrorLabel = (): string => {
   const entry = getCurrentMirrorEntry();
-  if (!entry) {
-    return undefined;
-  }
   try {
-    return new URL(entry).origin;
+    return new URL(entry, window.location.origin).host || entry;
   } catch {
-    return undefined;
+    return entry;
   }
 };
 
-export const probeApiAvailability = (callback: (available: boolean) => void): void => {
-  setApiStatus('checking', 'unknown', 'Checking mirror capabilities...');
-  const baseUrl = getMirrorBaseUrl();
+export const probeApiAvailability = (callback: (mirrorType: MirrorType) => void): void => {
+  const configuredMirrorType = getConfiguredMirrorType();
+  if (configuredMirrorType === 'static') {
+    setApiAvailability(false);
+    setApiStatus(
+      'unavailable',
+      'static',
+      'Selected mirror is a static mirror without CPL server features.',
+    );
+    callback('static');
+    return;
+  }
+
+  setApiStatus(
+    'checking',
+    configuredMirrorType === 'server' ? 'server' : 'unknown',
+    configuredMirrorType === 'server'
+      ? `Checking server mirror ${getMirrorLabel()}...`
+      : 'Checking mirror capabilities...',
+  );
   rawApiRequest<JsonObject>(
     'GET',
     `/stats/${encodeURIComponent('$:/plugins/Gk0Wk/CPL-Repo/__probe__')}`,
     null,
     error => {
       if (error) {
+        const mirrorType = configuredMirrorType === 'server' ? 'unreachable' : 'unknown';
         setApiAvailability(false);
         setApiStatus(
           'unavailable',
-          'static',
-          'Static mirror detected. Stats, ratings, comments, and login are unavailable here.',
+          mirrorType,
+          configuredMirrorType === 'server'
+            ? `Configured server mirror ${getMirrorOrigin()} is currently unreachable or unavailable.`
+            : `Mirror ${getMirrorLabel()} does not expose CPL server features or is currently unreachable.`,
         );
-        callback(false);
+        callback(mirrorType);
         return;
       }
 
       setApiAvailability(true);
       setApiStatus('available', 'server', 'Full CPL server features are available on this mirror.');
-      callback(true);
+      callback('server');
     },
-    undefined,
-    baseUrl,
   );
 };
 
@@ -52,12 +83,9 @@ export const refreshMirrorCapabilityState = (cplServerApi: CPLServerApi): void =
   setLastMirrorEntry(entry);
   setApiAvailability(null);
   clearServerTempState();
-  probeApiAvailability(available => {
-    if (!available) {
-      tw.wiki.addTiddler({
-        title: '$:/temp/CPL-Server/user-status',
-        text: 'anonymous',
-      });
+  probeApiAvailability(mirrorType => {
+    if (mirrorType !== 'server') {
+      setAnonymousUserStatus();
       return;
     }
 
@@ -75,10 +103,7 @@ export const refreshMirrorCapabilityState = (cplServerApi: CPLServerApi): void =
         return;
       }
 
-      tw.wiki.addTiddler({
-        title: '$:/temp/CPL-Server/user-status',
-        text: 'anonymous',
-      });
+      setAnonymousUserStatus();
     });
   });
 };

--- a/src/CPLPlugin/startup/api-client/state.ts
+++ b/src/CPLPlugin/startup/api-client/state.ts
@@ -1,8 +1,30 @@
-import { MIRROR_CONFIG_TITLE } from './constants';
+import {
+  CPL_API_BASE,
+  MIRROR_CONFIG_TITLE,
+  MIRROR_SERVER_REPOS_TITLE,
+  MIRROR_STATIC_REPOS_TITLE,
+} from './constants';
 import { tw } from './types';
+
+export type MirrorType = 'server' | 'static' | 'unreachable' | 'unknown';
 
 export let apiAvailability: boolean | null = null;
 export let lastMirrorEntry: string | null = null;
+
+const normalizeMirrorEntry = (entry: string): string => {
+  try {
+    return new URL(entry, window.location.origin).toString().replace(/\/$/, '');
+  } catch {
+    return entry.trim().replace(/\/$/, '');
+  }
+};
+
+const getConfiguredMirrorEntries = (title: string): Set<string> =>
+  new Set(
+    tw.utils
+      .parseStringArray(tw.wiki.getTiddlerText(title, ''))
+      .map(normalizeMirrorEntry),
+  );
 
 export const setApiAvailability = (value: boolean | null): void => {
   apiAvailability = value;
@@ -14,3 +36,28 @@ export const setLastMirrorEntry = (value: string | null): void => {
 
 export const getCurrentMirrorEntry = (): string =>
   tw.wiki.getTiddlerText(MIRROR_CONFIG_TITLE, '');
+
+export const getMirrorOrigin = (entry = getCurrentMirrorEntry()): string => {
+  try {
+    return new URL(entry, window.location.origin).origin;
+  } catch {
+    return window.location.origin;
+  }
+};
+
+export const getCurrentMirrorOrigin = (): string => getMirrorOrigin();
+
+export const getCurrentMirrorApiBase = (): string => `${getCurrentMirrorOrigin()}${CPL_API_BASE}`;
+
+export const getConfiguredMirrorType = (entry = getCurrentMirrorEntry()): MirrorType => {
+  const normalizedEntry = normalizeMirrorEntry(entry);
+  if (getConfiguredMirrorEntries(MIRROR_SERVER_REPOS_TITLE).has(normalizedEntry)) {
+    return 'server';
+  }
+
+  if (getConfiguredMirrorEntries(MIRROR_STATIC_REPOS_TITLE).has(normalizedEntry)) {
+    return 'static';
+  }
+
+  return 'unknown';
+};

--- a/src/CPLPlugin/views/plugins/comments.tid
+++ b/src/CPLPlugin/views/plugins/comments.tid
@@ -21,6 +21,15 @@ type: text/vnd.tiddlywiki
 </div>
 </div>
 </$list>
+<$list filter="[<mirrorType>match[unreachable]]" variable="isUnavailableMirror">
+<div class="cpl-static-feature-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
+<span style="font-size: 1.5em;">⚠️</span>
+<div>
+<strong><$text text={{{ [[$:/language]get[text]match[zh-CN]then[服务器镜像不可访问]else[Server Mirror Unreachable]] }}}/></strong>
+<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]match[zh-CN]then[当前选择的是服务器镜像，但它暂时无法访问，因此评论功能当前不可用。]else[The selected mirror should provide comments, but it is currently unreachable, so comments are unavailable right now.]] }}}/></p>
+</div>
+</div>
+</$list>
 
 <!-- Only show comment section for server mirrors -->
 <$list filter="[<mirrorType>match[server]]" variable="isServerMirror">

--- a/src/CPLPlugin/views/plugins/database.tid
+++ b/src/CPLPlugin/views/plugins/database.tid
@@ -30,6 +30,12 @@ type: text/vnd.tiddlywiki
 <$text text={{{ [<chinese>match[yes]then[静态镜像]else[Static Mirror]] }}}/>
 </span>
 </$list>
+<$list filter="[<mirrorType>match[unreachable]]" variable="isUnreachable">
+<span class="cpl-mirror-status cpl-mirror-unreachable" style="font-size: 0.85em; color: #dc3545; display: flex; align-items: center; gap: 4px;">
+<span style="font-size: 1.2em;">✗</span>
+<$text text={{{ [<chinese>match[yes]then[服务器镜像（不可访问）]else[Server Mirror (Unavailable)]] }}}/>
+</span>
+</$list>
 <$list filter="[<mirrorType>match[unknown]]" variable="isUnknown">
 <span class="cpl-mirror-status cpl-mirror-unknown" style="font-size: 0.85em; color: #999; display: flex; align-items: center; gap: 4px;">
 <span style="font-size: 1.2em;">?</span>
@@ -58,6 +64,14 @@ type: text/vnd.tiddlywiki
 <span style="font-size: 1.2em;">ℹ️</span>
 <div>
 <$text text={{{ [<chinese>match[yes]then[当前镜像为静态镜像，不支持评论、评分、统计等服务器功能。如需使用这些功能，请切换到服务器镜像。]else[Current mirror is a static mirror without server features (comments, ratings, stats). Switch to a server mirror to use these features.]] }}}/>
+</div>
+</div>
+</$list>
+<$list filter="[[$:/temp/CPL-Repo/mirror-type]get[text]match[unreachable]]" variable="isUnavailableMirror">
+<div class="cpl-static-mirror-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 4px; padding: 8px 12px; margin-bottom: 8px; font-size: 0.9em; display: flex; align-items: start; gap: 8px;">
+<span style="font-size: 1.2em;">⚠</span>
+<div>
+<$text text={{{ [<chinese>match[yes]then[当前选择的是服务器镜像，但该镜像暂时无法访问。评论、评分、统计和登录功能当前不可用。]else[The selected mirror is a server mirror, but it is currently unreachable. Comments, ratings, stats, and login are unavailable right now.]] }}}/>
 </div>
 </div>
 </$list>

--- a/src/CPLPlugin/views/plugins/stats.tid
+++ b/src/CPLPlugin/views/plugins/stats.tid
@@ -29,6 +29,15 @@ type: text/vnd.tiddlywiki
 </div>
 </div>
 </$list>
+<$list filter="[<mirrorType>match[unreachable]]" variable="isUnavailableMirror">
+<div class="cpl-static-feature-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
+<span style="font-size: 1.5em;">⚠️</span>
+<div>
+<strong><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[服务器镜像不可访问]else[Server Mirror Unreachable]] }}}/></strong>
+<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[当前选择的是服务器镜像，但它暂时无法访问，因此下载统计、评分和更新日志功能当前不可用。]else[The selected mirror should provide server features, but it is currently unreachable, so download stats, ratings, and changelog are unavailable.]] }}}/></p>
+</div>
+</div>
+</$list>
 
 <!-- Only show stats/rating/changelog for server mirrors -->
 <$list filter="[<mirrorType>match[server]]" variable="isServerMirror">


### PR DESCRIPTION
## Summary
- detect mirror status from the selected repo instead of the current page origin
- add unreachable server-mirror handling and include cpl.tidgi.fun as a configured server mirror
- restore build:library for deploys and add a root fallback entry plus direct CPL client download on /repo

## Validation
- pnpm run build
- pnpm run test:api
- pnpm run build:library