### PR TITLE
fix: correct CPL client download links

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -91,7 +91,7 @@ jobs:
                 <p style="margin:0; color:#475569;">The main wiki UI was not generated for this deployment, but the CPL mirror repository and client plugin are still available below.</p>
                 <div class="actions">
                   <a class="primary" href="repo/">Open repo mirror landing page</a>
-                  <a class="secondary" href="repo/plugins/Gk0Wk_CPL-Repo.json">Download CPL client plugin</a>
+                  <a class="secondary" href="library/plugins/Gk0Wk_CPL-Repo.json">Download CPL client plugin</a>
                 </div>
               </main>
             </body>

--- a/scripts/build/allplugins.emplate.html
+++ b/scripts/build/allplugins.emplate.html
@@ -278,7 +278,7 @@
       </p>
       <div class="actions">
         <a class="action primary" href="../#Welcome:Welcome">Open CPL Wiki UI</a>
-            <a class="action" href="plugins/Gk0Wk_CPL-Repo.json">Download CPL Client Plugin</a>
+        <a class="action" href="../library/plugins/Gk0Wk_CPL-Repo.json">Download CPL Client Plugin</a>
         <a class="action" href="index.json">Open plugin index JSON</a>
         <a class="action" href="plugins/">Browse exported plugin files</a>
       </div>
@@ -298,7 +298,7 @@
       </div>
       <p class="note">
         If you are opening this directly in a browser and expected an interactive gallery, use the wiki UI link above.
-        If the main CPL web UI is temporarily unavailable, you can still install the CPL client by dragging <code>plugins/Gk0Wk_CPL-Repo.json</code> into another wiki.
+        If the main CPL web UI is temporarily unavailable, you can still install the CPL client using the download link above.
         TiddlyWiki instances should keep pointing their mirror setting at this repo path, for example <code>/repo</code>.
       </p>
     </main>


### PR DESCRIPTION
## Summary
- point the repo landing page download button to the real exported CPL client plugin path under library/plugins
- point the root fallback page to the same working CPL client plugin path

## Validation
- pnpm run build
- pnpm run build:library
- verified cache/plugins/index.html links to ../library/plugins/Gk0Wk_CPL-Repo.json
- verified dist/library/plugins/Gk0Wk_CPL-Repo.json exists