### PR TITLE
fix: restore Modern.TiddlyDev root site deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -62,42 +62,8 @@ jobs:
         run: |
           pnpm run build
           node scripts/fetch-plugins.js --allow-ci --best-effort
+          pnpm run build:website
           pnpm run build:library
-
-      - name: Ensure root site entry exists
-        run: |
-          if [ ! -f dist/index.html ]; then
-            cat > dist/index.html <<'EOF'
-          <!DOCTYPE html>
-          <html lang="en">
-            <head>
-              <meta charset="utf-8" />
-              <meta name="viewport" content="width=device-width, initial-scale=1" />
-              <title>TiddlyWiki CPL</title>
-              <style>
-                body { font-family: system-ui, sans-serif; margin: 0; padding: 32px; background: #f8fafc; color: #0f172a; }
-                main { max-width: 760px; margin: 0 auto; background: #fff; border-radius: 16px; padding: 24px; box-shadow: 0 10px 30px rgba(15,23,42,.08); }
-                a { color: #2563eb; }
-                .actions { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 20px; }
-                .actions a { text-decoration: none; padding: 10px 16px; border-radius: 999px; font-weight: 600; }
-                .primary { background: #2563eb; color: #fff; }
-                .secondary { background: #e2e8f0; color: #0f172a; }
-              </style>
-            </head>
-            <body>
-              <main>
-                <p style="margin:0 0 8px; color:#64748b; text-transform:uppercase; letter-spacing:.08em; font-size:.9rem;">TiddlyWiki CPL</p>
-                <h1 style="margin:0 0 12px;">CPL Web UI Fallback</h1>
-                <p style="margin:0; color:#475569;">The main wiki UI was not generated for this deployment, but the CPL mirror repository and client plugin are still available below.</p>
-                <div class="actions">
-                  <a class="primary" href="repo/">Open repo mirror landing page</a>
-                  <a class="secondary" href="library/plugins/Gk0Wk_CPL-Repo.json">Download CPL client plugin</a>
-                </div>
-              </main>
-            </body>
-          </html>
-          EOF
-          fi
 
     #   - name: Minify Front Page HTML (also check if it exists)
     #     run: pnpm exec html-minifier-terser -c ./html-minifier-terser.config.json -o dist/index.html dist/index.html

--- a/README.md
+++ b/README.md
@@ -97,10 +97,12 @@ pnpm test:unit && pnpm test:api && pnpm test:e2e
 
 ### Building
 
-Build the static website and plugin JSON files:
+Build the deployable site artifacts from the Modern.TiddlyDev wiki and plugin library:
 
 ```bash
 pnpm build
+pnpm run build:website
+pnpm run build:library
 ```
 
 ### Adding Offline Plugin Files

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev:lan": "tiddlywiki-plugin-dev dev --wiki wiki --lan",
     "dev:wiki": "tiddlywiki-plugin-dev dev --wiki wiki --write-wiki",
     "build": "tiddlywiki-plugin-dev build --wiki wiki",
+    "build:website": "ts-node scripts/build-website.ts",
     "build:library": "ts-node scripts/build-library.ts",
     "import:libraries": "ts-node scripts/index.ts import library --all",
     "import:official-library": "ts-node scripts/index.ts import library --official",

--- a/scripts/build-website.ts
+++ b/scripts/build-website.ts
@@ -1,0 +1,25 @@
+#!/usr/bin/env ts-node
+
+import { buildOnlineHTML } from './build/website';
+
+const args = process.argv.slice(2);
+const outputArg = args.find(arg => arg.startsWith('--output='));
+const htmlNameArg = args.find(arg => arg.startsWith('--html='));
+const wikiArg = args.find(arg => arg.startsWith('--wiki='));
+
+const distDir = outputArg ? outputArg.slice('--output='.length) : undefined;
+const htmlName = htmlNameArg ? htmlNameArg.slice('--html='.length) : undefined;
+const wikiPath = wikiArg ? wikiArg.slice('--wiki='.length) : undefined;
+
+void (async () => {
+  try {
+    await buildOnlineHTML(
+      wikiPath ?? 'wiki',
+      distDir ?? 'dist',
+      htmlName ?? 'index.html',
+    );
+  } catch (error) {
+    console.error(error);
+    process.exit(1);
+  }
+})();

--- a/scripts/build/cpl-plugin.ts
+++ b/scripts/build/cpl-plugin.ts
@@ -1,5 +1,18 @@
+import { readJSONSync } from 'fs-extra';
+import { resolve } from 'path';
 import type { ITiddlyWiki, ITiddlerFields } from 'tiddlywiki';
 import { mergePluginInfo } from './merge';
+
+const fallbackPluginVersion = (() => {
+  try {
+    const pluginInfo = readJSONSync(resolve(__dirname, '../../src/CPLPlugin/plugin.info')) as {
+      version?: string;
+    };
+    return pluginInfo.version?.trim();
+  } catch {
+    return undefined;
+  }
+})();
 
 export const buildCPLPlugin = (
   $tw: ITiddlyWiki,
@@ -25,7 +38,10 @@ export const buildCPLPlugin = (
       cplPluginTiddlers[tiddler.title] = tiddler as any;
     });
   const plugin = {
-    version: $tw.wiki.getTiddlerText('CPL-Repo-Version')!.trim(),
+    version:
+      $tw.wiki.getTiddlerText('CPL-Repo-Version')?.trim() ||
+      fallbackPluginVersion ||
+      '0.0.0',
     type: 'application/json',
     title: '$:/plugins/Gk0Wk/CPL-Repo',
     'plugin-type': 'plugin',

--- a/scripts/build/website.ts
+++ b/scripts/build/website.ts
@@ -3,7 +3,7 @@ import fs from 'fs-extra';
 import chalk from 'chalk';
 import type { ITiddlerFields } from 'tiddlywiki';
 
-import { tiddlywiki, waitForFile, shellI, getTmpDir } from '../utils';
+import { tiddlywiki, waitForFile, getTmpDir } from '../utils';
 import { buildCPLPlugin } from './cpl-plugin';
 
 /** 项目路径 */
@@ -87,7 +87,11 @@ export const buildOnlineHTML = async (
 
   // 拷贝公共资源
   console.log(chalk.bgCyan.black.bold('\nCopying public assets...'));
-  shellI(`cp -r ${publicDir}${path.sep} ${distDir}`);
+  for (const entry of fs.readdirSync(publicDir)) {
+    fs.copySync(path.resolve(publicDir, entry), path.resolve(distDir, entry), {
+      overwrite: true,
+    });
+  }
 
   // 缓存策略
   tiddlers.set(headerMetadataTiddler.title, headerMetadataTiddler);


### PR DESCRIPTION
## Summary
- restore a dedicated Modern.TiddlyDev root-site build step for the wiki under wiki/
- wire the deploy workflow to publish the real root TiddlyWiki site instead of generating a fallback landing page
- keep the library build intact and make the website build work cross-platform plus without a CPL-Repo-Version tiddler

## Validation
- pnpm run build:website
- pnpm run build
- pnpm run build:website
- pnpm run build:library
- verified dist/index.html exists and is not the fallback page
- verified dist/library/index.html exists