### PR TITLE
fix(web): restore plugin metadata templates in website build

### DIFF
--- a/scripts/build/cpl-plugin.ts
+++ b/scripts/build/cpl-plugin.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import type { ITiddlyWiki, ITiddlerFields } from 'tiddlywiki';
 import { mergePluginInfo } from './merge.ts';
 import { getTiddlerFromFile } from '../utils/tiddler.ts';
+import { getRuntimePluginTiddlers } from '../runtime-plugins.ts';
 
 interface SourcePluginInfo {
   title?: string;
@@ -85,13 +86,15 @@ export const buildCPLPlugin = (
 ] => {
   const pluginVersion = getBuiltPluginVersion($tw);
   const pluginReadme = getBuiltPluginReadme($tw);
+  const sourceRuntimeTiddlers = getRuntimePluginTiddlers('repo');
   const cplPluginTiddlers: Record<string, ITiddlerFields> = {};
-  $tw.wiki
-    .filterTiddlers(
-      '[tag[$:/tags/PluginLibrary/CPL]] [prefix[$:/plugins/Gk0Wk/CPL-Repo/]] -$:/plugins/Gk0Wk/CPL-Repo/config/popup-readme-at-startup -$:/plugins/Gk0Wk/CPL-Repo/config/auto-update-intervals-minutes',
-    )
-    .map(title => ({
-      ...$tw.wiki.getTiddler(title)!.fields,
+  Object.values(sourceRuntimeTiddlers)
+    .filter(({ title }) => ![
+      '$:/plugins/Gk0Wk/CPL-Repo/config/popup-readme-at-startup',
+      '$:/plugins/Gk0Wk/CPL-Repo/config/auto-update-intervals-minutes',
+    ].includes(title))
+    .map(tiddler => ({
+      ...tiddler,
       created: undefined,
       creator: undefined,
       modified: undefined,

--- a/scripts/build/website.ts
+++ b/scripts/build/website.ts
@@ -5,6 +5,7 @@ import type { ITiddlerFields } from 'tiddlywiki';
 
 import { tiddlywiki, waitForFile, getTmpDir } from '../utils/index.ts';
 import { buildCPLPlugin } from './cpl-plugin.ts';
+import { getRuntimePluginTiddlers } from '../runtime-plugins.ts';
 
 /** 项目路径 */
 const bypassTiddlers = new Set([
@@ -51,6 +52,7 @@ export const buildOnlineHTML = async (
   console.log(chalk.bgCyan.black.bold('\nExporting media tiddlers...'));
   const $tw = tiddlywiki([], wikiFolder);
   const tiddlers: Map<string, ITiddlerFields> = new Map();
+  const sourceRepoPluginTiddlers = getRuntimePluginTiddlers('repo');
   const assetsPath = path.resolve(distDir, 'assets');
   fs.ensureFileSync(path.resolve(assetsPath, '1'));
   $tw.wiki.each(({ fields }, title: string) => {
@@ -84,6 +86,16 @@ export const buildOnlineHTML = async (
       tiddlers.set(title, { ...fields });
     }
   });
+
+  // Overlay the current src/CPLPlugin runtime tiddlers so the website uses the
+  // same UI/templates as the built plugin instead of legacy wiki-side copies.
+  Object.values(sourceRepoPluginTiddlers).forEach(tiddler => {
+    tiddlers.set(tiddler.title, { ...tiddler } as ITiddlerFields);
+  });
+
+  // Remove legacy wiki-side title cascade that overrides the newer detail page.
+  tiddlers.delete('Plugin Info Title Cascade');
+  tiddlers.delete('Plugin Info Title');
 
   // 拷贝公共资源
   console.log(chalk.bgCyan.black.bold('\nCopying public assets...'));

--- a/scripts/runtime-plugins.ts
+++ b/scripts/runtime-plugins.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
 
 interface RuntimePluginFiles {
   repoPluginPath: string;
@@ -24,7 +25,10 @@ interface PackedPluginText {
   tiddlers: Record<string, PackedTiddler>;
 }
 
-const REPO_ROOT = path.resolve(__dirname, '..');
+type RuntimePluginName = 'repo' | 'server';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
 const PLUGIN_DEV_ENTRY = path.join(
   REPO_ROOT,
   'node_modules',
@@ -137,4 +141,14 @@ function ensureRuntimePluginsBuilt(): RuntimePluginFiles {
   return runtimePluginFiles;
 }
 
-export { ensureRuntimePluginsBuilt, runtimePluginFiles };
+function getRuntimePluginTiddlers(pluginName: RuntimePluginName): Record<string, PackedTiddler> {
+  ensureRuntimePluginsBuilt();
+
+  const pluginPath = pluginName === 'repo' ? REPO_PLUGIN_PATH : SERVER_PLUGIN_PATH;
+  const json = JSON.parse(fs.readFileSync(pluginPath, 'utf8')) as PackedPluginJson;
+  const parsedText = JSON.parse(json.text) as PackedPluginText;
+
+  return parsedText.tiddlers ?? {};
+}
+
+export { ensureRuntimePluginsBuilt, getRuntimePluginTiddlers, runtimePluginFiles };

--- a/scripts/runtime-plugins.ts
+++ b/scripts/runtime-plugins.ts
@@ -1,7 +1,6 @@
 import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { fileURLToPath } from 'url';
 
 interface RuntimePluginFiles {
   repoPluginPath: string;
@@ -27,8 +26,7 @@ interface PackedPluginText {
 
 type RuntimePluginName = 'repo' | 'server';
 
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.resolve(SCRIPT_DIR, '..');
+const REPO_ROOT = path.resolve(process.cwd());
 const PLUGIN_DEV_ENTRY = path.join(
   REPO_ROOT,
   'node_modules',

--- a/src/CPLPlugin/filters/cpl/plugin-view-template.tid
+++ b/src/CPLPlugin/filters/cpl/plugin-view-template.tid
@@ -5,4 +5,4 @@ tags: TW5CPL $:/tags/ViewTemplateBodyFilter
 title: $:/plugins/Gk0Wk/CPL-Repo/filters/cpl/plugin-view-template
 type: text/vnd.tiddlywiki
 
-[tag[$:/tags/PluginWiki]then[$:/plugins/Gk0Wk/CPL-Repo/templates/cpl/plugin-view]]
+[tag[$:/tags/PluginWiki]!title[$:/plugins/Gk0Wk/CPL-Repo/views/plugins/plugin-detail]then[$:/plugins/Gk0Wk/CPL-Repo/templates/cpl/plugin-view]]

--- a/src/CPLPlugin/filters/cpl/view-template-title.tid
+++ b/src/CPLPlugin/filters/cpl/view-template-title.tid
@@ -4,4 +4,4 @@ tags: $:/tags/ViewTemplateTitleFilter TW5CPL
 title: $:/plugins/Gk0Wk/CPL-Repo/filters/cpl/view-template-title
 type: text/vnd.tiddlywiki
 
-[tag[$:/tags/PluginWiki]then[$:/plugins/Gk0Wk/CPL-Repo/templates/cpl/view-template-title]]
+[tag[$:/tags/PluginWiki]!title[$:/plugins/Gk0Wk/CPL-Repo/views/plugins/plugin-detail]then[$:/plugins/Gk0Wk/CPL-Repo/templates/cpl/view-template-title]]


### PR DESCRIPTION
## Summary
- make website build overlay the current src-derived CPL runtime plugin tiddlers instead of relying on stale wiki-side copies
- build the downloadable CPL plugin package from the same runtime plugin tiddlers so website and plugin payload stay in sync
- exclude the dedicated plugin-detail page from the legacy PluginWiki title/body template filters and drop the old website-only title cascade from the generated site

## Root cause
The deployed web wiki was still rendering legacy tiddlers from wiki/tiddlers such as Plugin Info Title Cascade, while the current PluginWiki body/title templates from src/CPLPlugin were missing from the generated site. That left plugin pages like linonetwo/commandpalette with only sparse title text and no cpl.* metadata body.

## Validation
- pnpm run build:website
- local headless browser check for http://127.0.0.1:4173/#linonetwo/commandpalette now shows author, docs, source, readme, and attribution metadata
- pnpm run build:library