### PR TITLE
fix(cpl): decouple api server from repo mirror

### DIFF
--- a/src/CPLPlugin/config/current-server.tid
+++ b/src/CPLPlugin/config/current-server.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/Gk0Wk/CPL-Repo/config/current-server
+
+https://cpl.tidgi.fun

--- a/src/CPLPlugin/config/defaults.multids
+++ b/src/CPLPlugin/config/defaults.multids
@@ -4,5 +4,7 @@ update-filter: [has[plugin-type]] -[prefix[$:/temp/]] -[[$:/core]]
 repos: https://tw-cpl.netlify.app/repo https://tiddly-gittly.github.io/TiddlyWiki-CPL/repo https://cpl.tidgi.fun/repo
 static-repos: https://tw-cpl.netlify.app/repo https://tiddly-gittly.github.io/TiddlyWiki-CPL/repo
 server-repos: https://cpl.tidgi.fun/repo
+servers: https://cpl.tidgi.fun
 current-repo: https://tw-cpl.netlify.app/repo
+current-server: https://cpl.tidgi.fun
 auto-refresh-at-startup: yes

--- a/src/CPLPlugin/config/servers.tid
+++ b/src/CPLPlugin/config/servers.tid
@@ -1,0 +1,3 @@
+title: $:/plugins/Gk0Wk/CPL-Repo/config/servers
+
+https://cpl.tidgi.fun

--- a/src/CPLPlugin/startup/api-client.ts
+++ b/src/CPLPlugin/startup/api-client.ts
@@ -1,6 +1,6 @@
 import { tw, type RootWidgetEvent, type OAuthResponse } from './api-client/types';
-import { MIRROR_CONFIG_TITLE } from './api-client/constants';
-import { getCurrentMirrorOrigin } from './api-client/state';
+import { MIRROR_CONFIG_TITLE, SERVER_CONFIG_TITLE } from './api-client/constants';
+import { getCurrentServerOrigin } from './api-client/state';
 import { getEventParam, getViewedPluginTitle } from './api-client/utilities';
 import { setJwtToken } from './api-client/auth';
 import { createCplServerApi } from './api-client/api';
@@ -20,7 +20,7 @@ export const startup = (): void => {
   refreshMirrorCapabilityState(cplServerApi);
 
   tw.wiki.addEventListener('change', changes => {
-    if ($tw.utils.hop(changes, MIRROR_CONFIG_TITLE)) {
+    if ($tw.utils.hop(changes, MIRROR_CONFIG_TITLE) || $tw.utils.hop(changes, SERVER_CONFIG_TITLE)) {
       refreshMirrorCapabilityState(cplServerApi);
     }
 
@@ -142,7 +142,7 @@ export const startup = (): void => {
       console.error('[CPL-Server] GitHub client ID not available. Server may not have OAuth configured.');
       return undefined;
     }
-    const redirectUri = `${getCurrentMirrorOrigin()}/cpl/api/auth/github/callback`;
+    const redirectUri = `${window.location.origin}/cpl/api/auth/github/callback`;
     const githubAuthUrl = `https://github.com/login/oauth/authorize?client_id=${encodeURIComponent(githubClientId)}&redirect_uri=${encodeURIComponent(redirectUri)}&scope=user:read`;
     window.location.href = githubAuthUrl;
     return undefined;
@@ -152,7 +152,7 @@ export const startup = (): void => {
     const code = new URLSearchParams(window.location.search).get('code');
     if (code) {
       tw.utils.httpRequest({
-        url: `${getCurrentMirrorOrigin()}/cpl/api/auth/github/callback?code=${encodeURIComponent(code)}`,
+        url: `${getCurrentServerOrigin()}/cpl/api/auth/github/callback?code=${encodeURIComponent(code)}`,
         type: 'GET',
         headers: { 'Content-Type': 'application/json' },
         callback: (error: unknown, response: string) => {

--- a/src/CPLPlugin/startup/api-client/api.ts
+++ b/src/CPLPlugin/startup/api-client/api.ts
@@ -19,7 +19,7 @@ export const createCplServerApi = (): CPLServerApi => ({
     apiRequest('GET', `/changelog/${encodeURIComponent(pluginTitle)}`, null, callback);
   },
   getComments(pluginTitle, callback) {
-    authenticatedRequest('GET', `/comments/${encodeURIComponent(pluginTitle)}`, null, callback);
+    apiRequest('GET', `/comments/${encodeURIComponent(pluginTitle)}`, null, callback);
   },
   submitComment(pluginTitle, content, callback) {
     authenticatedRequest('POST', `/comments/${encodeURIComponent(pluginTitle)}`, { content }, callback);

--- a/src/CPLPlugin/startup/api-client/constants.ts
+++ b/src/CPLPlugin/startup/api-client/constants.ts
@@ -1,8 +1,11 @@
 export const CPL_API_BASE = '/cpl/api';
 export const API_STATUS_TIDDLER = '$:/temp/CPL-Repo/api-status';
-export const API_TYPE_TIDDLER = '$:/temp/CPL-Repo/mirror-type';
-export const API_MESSAGE_TIDDLER = '$:/temp/CPL-Repo/mirror-message';
+export const API_TYPE_TIDDLER = '$:/temp/CPL-Repo/server-type';
+export const API_MESSAGE_TIDDLER = '$:/temp/CPL-Repo/server-message';
+export const REPO_TYPE_TIDDLER = '$:/temp/CPL-Repo/mirror-type';
 export const MIRROR_CONFIG_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/current-repo';
 export const MIRROR_STATIC_REPOS_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/static-repos';
 export const MIRROR_SERVER_REPOS_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/server-repos';
+export const SERVER_CONFIG_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/current-server';
+export const SERVER_LIST_TITLE = '$:/plugins/Gk0Wk/CPL-Repo/config/servers';
 export const JWT_TOKEN_KEY = 'cpl_jwt_token';

--- a/src/CPLPlugin/startup/api-client/server-status.ts
+++ b/src/CPLPlugin/startup/api-client/server-status.ts
@@ -1,15 +1,16 @@
 import { tw, type CPLServerApi, type JsonObject } from './types';
 import { rawApiRequest } from './http';
-import { setApiStatus, clearServerTempState } from './utilities';
+import { setApiStatus, clearServerTempState, setRepoType } from './utilities';
 import {
   getConfiguredMirrorType,
   getCurrentMirrorEntry,
-  getMirrorOrigin,
+  getCurrentServerEntry,
+  getCurrentServerOrigin,
   apiAvailability,
   lastMirrorEntry,
   setApiAvailability,
   setLastMirrorEntry,
-  type MirrorType,
+  type ApiServerType,
 } from './state';
 
 const setAnonymousUserStatus = (): void => {
@@ -20,7 +21,7 @@ const setAnonymousUserStatus = (): void => {
 };
 
 const getMirrorLabel = (): string => {
-  const entry = getCurrentMirrorEntry();
+  const entry = getCurrentServerEntry();
   try {
     return new URL(entry, window.location.origin).host || entry;
   } catch {
@@ -28,25 +29,22 @@ const getMirrorLabel = (): string => {
   }
 };
 
-export const probeApiAvailability = (callback: (mirrorType: MirrorType) => void): void => {
-  const configuredMirrorType = getConfiguredMirrorType();
-  if (configuredMirrorType === 'static') {
+export const probeApiAvailability = (callback: (serverType: ApiServerType) => void): void => {
+  if (!getCurrentServerEntry()) {
     setApiAvailability(false);
     setApiStatus(
       'unavailable',
-      'static',
-      'Selected mirror is a static mirror without CPL server features.',
+      'unknown',
+      'No CPL server is configured.',
     );
-    callback('static');
+    callback('unknown');
     return;
   }
 
   setApiStatus(
     'checking',
-    configuredMirrorType === 'server' ? 'server' : 'unknown',
-    configuredMirrorType === 'server'
-      ? `Checking server mirror ${getMirrorLabel()}...`
-      : 'Checking mirror capabilities...',
+    'unknown',
+    `Checking CPL server ${getMirrorLabel()}...`,
   );
   rawApiRequest<JsonObject>(
     'GET',
@@ -54,34 +52,32 @@ export const probeApiAvailability = (callback: (mirrorType: MirrorType) => void)
     null,
     error => {
       if (error) {
-        const mirrorType = configuredMirrorType === 'server' ? 'unreachable' : 'unknown';
         setApiAvailability(false);
         setApiStatus(
           'unavailable',
-          mirrorType,
-          configuredMirrorType === 'server'
-            ? `Configured server mirror ${getMirrorOrigin()} is currently unreachable or unavailable.`
-            : `Mirror ${getMirrorLabel()} does not expose CPL server features or is currently unreachable.`,
+          'unreachable',
+          `Configured CPL server ${getCurrentServerOrigin()} is currently unreachable or unavailable.`,
         );
-        callback(mirrorType);
+        callback('unreachable');
         return;
       }
 
       setApiAvailability(true);
-      setApiStatus('available', 'server', 'Full CPL server features are available on this mirror.');
+      setApiStatus('available', 'server', `CPL server ${getMirrorLabel()} is available.`);
       callback('server');
     },
   );
 };
 
 export const refreshMirrorCapabilityState = (cplServerApi: CPLServerApi): void => {
-  const entry = getCurrentMirrorEntry();
-  if (entry === lastMirrorEntry && apiAvailability !== null) {
+  const signature = `${getCurrentMirrorEntry()}|${getCurrentServerEntry()}`;
+  if (signature === lastMirrorEntry && apiAvailability !== null) {
     return;
   }
 
-  setLastMirrorEntry(entry);
+  setLastMirrorEntry(signature);
   setApiAvailability(null);
+  setRepoType(getConfiguredMirrorType());
   clearServerTempState();
   probeApiAvailability(mirrorType => {
     if (mirrorType !== 'server') {

--- a/src/CPLPlugin/startup/api-client/state.ts
+++ b/src/CPLPlugin/startup/api-client/state.ts
@@ -3,15 +3,18 @@ import {
   MIRROR_CONFIG_TITLE,
   MIRROR_SERVER_REPOS_TITLE,
   MIRROR_STATIC_REPOS_TITLE,
+  SERVER_CONFIG_TITLE,
+  SERVER_LIST_TITLE,
 } from './constants';
 import { tw } from './types';
 
-export type MirrorType = 'server' | 'static' | 'unreachable' | 'unknown';
+export type MirrorType = 'server' | 'static' | 'unknown';
+export type ApiServerType = 'server' | 'unreachable' | 'unknown';
 
 export let apiAvailability: boolean | null = null;
 export let lastMirrorEntry: string | null = null;
 
-const normalizeMirrorEntry = (entry: string): string => {
+const normalizeUrlEntry = (entry: string): string => {
   try {
     return new URL(entry, window.location.origin).toString().replace(/\/$/, '');
   } catch {
@@ -23,8 +26,11 @@ const getConfiguredMirrorEntries = (title: string): Set<string> =>
   new Set(
     tw.utils
       .parseStringArray(tw.wiki.getTiddlerText(title, ''))
-      .map(normalizeMirrorEntry),
+      .map(normalizeUrlEntry),
   );
+
+const getConfiguredServerEntries = (): string[] =>
+  tw.utils.parseStringArray(tw.wiki.getTiddlerText(SERVER_LIST_TITLE, ''));
 
 export const setApiAvailability = (value: boolean | null): void => {
   apiAvailability = value;
@@ -37,6 +43,9 @@ export const setLastMirrorEntry = (value: string | null): void => {
 export const getCurrentMirrorEntry = (): string =>
   tw.wiki.getTiddlerText(MIRROR_CONFIG_TITLE, '');
 
+export const getCurrentServerEntry = (): string =>
+  tw.wiki.getTiddlerText(SERVER_CONFIG_TITLE, getConfiguredServerEntries()[0] ?? '');
+
 export const getMirrorOrigin = (entry = getCurrentMirrorEntry()): string => {
   try {
     return new URL(entry, window.location.origin).origin;
@@ -45,12 +54,22 @@ export const getMirrorOrigin = (entry = getCurrentMirrorEntry()): string => {
   }
 };
 
+export const getServerOrigin = (entry = getCurrentServerEntry()): string => {
+  try {
+    return new URL(entry, window.location.origin).origin;
+  } catch {
+    return '';
+  }
+};
+
 export const getCurrentMirrorOrigin = (): string => getMirrorOrigin();
 
-export const getCurrentMirrorApiBase = (): string => `${getCurrentMirrorOrigin()}${CPL_API_BASE}`;
+export const getCurrentServerOrigin = (): string => getServerOrigin();
+
+export const getCurrentMirrorApiBase = (): string => `${getCurrentServerOrigin()}${CPL_API_BASE}`;
 
 export const getConfiguredMirrorType = (entry = getCurrentMirrorEntry()): MirrorType => {
-  const normalizedEntry = normalizeMirrorEntry(entry);
+  const normalizedEntry = normalizeUrlEntry(entry);
   if (getConfiguredMirrorEntries(MIRROR_SERVER_REPOS_TITLE).has(normalizedEntry)) {
     return 'server';
   }

--- a/src/CPLPlugin/startup/api-client/utilities.ts
+++ b/src/CPLPlugin/startup/api-client/utilities.ts
@@ -1,5 +1,10 @@
 import { tw, type RootWidgetEvent, type HttpErrorLike } from './types';
-import { API_STATUS_TIDDLER, API_TYPE_TIDDLER, API_MESSAGE_TIDDLER } from './constants';
+import {
+  API_STATUS_TIDDLER,
+  API_TYPE_TIDDLER,
+  API_MESSAGE_TIDDLER,
+  REPO_TYPE_TIDDLER,
+} from './constants';
 
 export const getEventParam = (event: RootWidgetEvent, name: string): string | undefined => {
   const value = event.paramObject?.[name];
@@ -29,6 +34,14 @@ export const setApiStatus = (status: string, type: string, message: string): voi
     title: API_MESSAGE_TIDDLER,
     text: message || '',
     timestamp,
+  });
+};
+
+export const setRepoType = (type: string): void => {
+  tw.wiki.addTiddler({
+    title: REPO_TYPE_TIDDLER,
+    text: type || 'unknown',
+    timestamp: String(Date.now()),
   });
 };
 

--- a/src/CPLPlugin/views/plugins/comments.tid
+++ b/src/CPLPlugin/views/plugins/comments.tid
@@ -9,34 +9,14 @@ type: text/vnd.tiddlywiki
 <!-- Comment Section for Plugin Pages -->
 <$list filter="[all[current]tag[$:/tags/PluginWiki]has[cpl.title]]" variable="pluginTiddler">
 
-<$let pluginTitle={{!!cpl.title}} userStatus={{{ [[$:/temp/CPL-Server/user-status]get[text]else[anonymous]] }}} mirrorType={{{ [[$:/temp/CPL-Repo/mirror-type]get[text]else[unknown]] }}}>
-
-<!-- Static Mirror Notice -->
-<$list filter="[<mirrorType>match[static]]" variable="isStaticMirror">
-<div class="cpl-static-feature-notice" style="background: #fff3cd; border: 1px solid #ffc107; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
-<span style="font-size: 1.5em;">ℹ️</span>
-<div>
-<strong><$text text={{{ [[$:/language]get[text]match[zh-CN]then[评论功能不可用]else[Comments Unavailable]] }}}/></strong>
-<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]match[zh-CN]then[当前镜像为静态镜像，不支持评论功能。切换到服务器镜像以查看和发表评论。]else[Current mirror is a static mirror. Comments are not available. Switch to a server mirror to view and post comments.]] }}}/></p>
-</div>
-</div>
-</$list>
-<$list filter="[<mirrorType>match[unreachable]]" variable="isUnavailableMirror">
-<div class="cpl-static-feature-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
-<span style="font-size: 1.5em;">⚠️</span>
-<div>
-<strong><$text text={{{ [[$:/language]get[text]match[zh-CN]then[服务器镜像不可访问]else[Server Mirror Unreachable]] }}}/></strong>
-<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]match[zh-CN]then[当前选择的是服务器镜像，但它暂时无法访问，因此评论功能当前不可用。]else[The selected mirror should provide comments, but it is currently unreachable, so comments are unavailable right now.]] }}}/></p>
-</div>
-</div>
-</$list>
+<$let pluginTitle={{!!cpl.title}} userStatus={{{ [[$:/temp/CPL-Server/user-status]get[text]else[anonymous]] }}} serverType={{{ [[$:/temp/CPL-Repo/server-type]get[text]else[unknown]] }}} chinese={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[yes]else[no]] }}}>
 
 <!-- Only show comment section for server mirrors -->
-<$list filter="[<mirrorType>match[server]]" variable="isServerMirror">
+<$list filter="[<serverType>match[server]]" variable="isServerMirror">
 
 <div class="cpl-comment-section" style="margin: 20px 0; padding: 16px; background: #f8f9fa; border-radius: 8px; border: 1px solid #e9ecef;">
   <h3 style="margin-top: 0; border-bottom: 2px solid #dee2e6; padding-bottom: 8px;">
-    💬 <$text text={{{ [[$:/language]get[text]match[zh-CN]then[评论]else[Comments]] }}}/>
+    💬 <$text text={{{ [<chinese>match[yes]then[评论]else[Comments]] }}}/>
   </h3>
 
   <!-- Login Status -->
@@ -52,7 +32,7 @@ type: text/vnd.tiddlywiki
         <$action-deletetiddler $tiddler="$:/temp/CPL-Server/user"/>
         <$action-deletetiddler $tiddler="$:/temp/CPL-Server/user-status"/>
         <$action-sendmessage $message="cpl-logout"/>
-        <$text text={{{ [[$:/language]get[text]match[zh-CN]then[退出登录]else[Logout]] }}}/>
+        <$text text={{{ [<chinese>match[yes]then[退出登录]else[Logout]] }}}/>
       </$button>
     </div>
     </$let>
@@ -61,10 +41,10 @@ type: text/vnd.tiddlywiki
     <div style="margin-bottom: 20px;">
       <$edit-text tiddler="$:/temp/CPL-Server/comment-draft" field="text" class="cpl-comment-textarea" tag="textarea" style="width: 100%; min-height: 80px; padding: 10px; border: 1px solid #ced4da; border-radius: 4px; resize: vertical; font-family: inherit;" placeholder="Write a comment using wikitext..."/>
       <div style="margin-top: 8px; display: flex; justify-content: space-between; align-items: center;">
-        <span style="font-size: 0.85em; color: #666;">Wikitext supported</span>
+        <span style="font-size: 0.85em; color: #666;"><$text text={{{ [<chinese>match[yes]then[支持 Wikitext]else[Wikitext supported]] }}}/></span>
         <$button class="tc-btn-primary" style="padding: 8px 20px;">
           <$action-sendmessage $message="cpl-submit-comment" pluginTitle=<<pluginTitle>>/>
-          <$text text={{{ [[$:/language]get[text]match[zh-CN]then[提交评论]else[Submit Comment]] }}}/>
+          <$text text={{{ [<chinese>match[yes]then[提交评论]else[Submit Comment]] }}}/>
         </$button>
       </div>
       <$let commentStatus={{{ [[$:/temp/CPL-Server/comment-status/]addsuffix<pluginTitle>] }}}>
@@ -75,7 +55,7 @@ type: text/vnd.tiddlywiki
         </$list>
         <$list filter="[<commentStatus>get[text]match[success]]" variable="hasSuccess">
           <div style="margin-top: 8px; color: #28a745; font-size: 0.9em;">
-            ✓ <$text text={{{ [[$:/language]get[text]match[zh-CN]then[评论已提交，等待审核]else[Comment submitted for moderation]] }}}/>
+            ✓ <$text text={{{ [<chinese>match[yes]then[评论已提交，等待审核]else[Comment submitted for moderation]] }}}/>
           </div>
         </$list>
       </$let>
@@ -86,12 +66,12 @@ type: text/vnd.tiddlywiki
     <!-- Not logged in: Show login button -->
     <div style="text-align: center; padding: 20px; background: #fff; border-radius: 6px; margin-bottom: 16px;">
       <p style="margin: 0 0 12px 0; color: #666;">
-        <$text text={{{ [[$:/language]get[text]match[zh-CN]then[登录后即可发表评论]else[Login to post comments]] }}}/>
+        <$text text={{{ [<chinese>match[yes]then[登录后即可发表评论]else[Login to post comments]] }}}/>
       </p>
       <$button class="tc-btn-primary" style="padding: 10px 24px;">
         <$action-sendmessage $message="cpl-github-login"/>
         <span style="margin-right: 6px;">🔗</span>
-        <$text text={{{ [[$:/language]get[text]match[zh-CN]then[使用 GitHub 登录]else[Login with GitHub]] }}}/>
+        <$text text={{{ [<chinese>match[yes]then[使用 GitHub 登录]else[Login with GitHub]] }}}/>
       </button>
     </div>
   </$list>
@@ -119,7 +99,7 @@ type: text/vnd.tiddlywiki
       </$list>
       <$list filter="[<commentsJson>jsonget[comments]length[]compare:integer:eq[0]]" variable="noComments">
         <div style="text-align: center; padding: 20px; color: #999; font-style: italic;">
-          <$text text={{{ [[$:/language]get[text]match[zh-CN]then[暂无评论，来发表第一条吧！]else[No comments yet. Be the first!]] }}}/>
+          <$text text={{{ [<chinese>match[yes]then[暂无评论，来发表第一条吧！]else[No comments yet. Be the first!]] }}}/>
         </div>
       </$list>
     </$let>

--- a/src/CPLPlugin/views/plugins/database.tid
+++ b/src/CPLPlugin/views/plugins/database.tid
@@ -17,7 +17,7 @@ type: text/vnd.tiddlywiki
 </$select>
 
 <!-- Mirror Status Indicator -->
-<$let mirrorType={{{ [[$:/temp/CPL-Repo/mirror-type]get[text]else[unknown]] }}} switchStatus={{{ [[$:/temp/CPL-Repo/mirror-switch-status]get[text]else[]] }}} switchMessage={{{ [[$:/temp/CPL-Repo/mirror-switch-status]get[message]else[]] }}}>
+<$let mirrorType={{{ [[$:/temp/CPL-Repo/mirror-type]get[text]else[unknown]] }}} serverType={{{ [[$:/temp/CPL-Repo/server-type]get[text]else[unknown]] }}} switchStatus={{{ [[$:/temp/CPL-Repo/mirror-switch-status]get[text]else[]] }}} switchMessage={{{ [[$:/temp/CPL-Repo/mirror-switch-status]get[message]else[]] }}}>
 <$list filter="[<mirrorType>match[server]]" variable="isServer">
 <span class="cpl-mirror-status cpl-mirror-server" style="font-size: 0.85em; color: #28a745; display: flex; align-items: center; gap: 4px;">
 <span style="font-size: 1.2em;">✓</span>
@@ -58,20 +58,11 @@ type: text/vnd.tiddlywiki
 </div>
 </$list>
 
-<!-- Static Mirror Info Banner -->
-<$list filter="[[$:/temp/CPL-Repo/mirror-type]get[text]match[static]]" variable="isStaticMirror">
-<div class="cpl-static-mirror-notice" style="background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; padding: 8px 12px; margin-bottom: 8px; font-size: 0.9em; display: flex; align-items: start; gap: 8px;">
-<span style="font-size: 1.2em;">ℹ️</span>
-<div>
-<$text text={{{ [<chinese>match[yes]then[当前镜像为静态镜像，不支持评论、评分、统计等服务器功能。如需使用这些功能，请切换到服务器镜像。]else[Current mirror is a static mirror without server features (comments, ratings, stats). Switch to a server mirror to use these features.]] }}}/>
-</div>
-</div>
-</$list>
-<$list filter="[[$:/temp/CPL-Repo/mirror-type]get[text]match[unreachable]]" variable="isUnavailableMirror">
+<$list filter="[<serverType>match[unreachable]]" variable="isUnavailableServer">
 <div class="cpl-static-mirror-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 4px; padding: 8px 12px; margin-bottom: 8px; font-size: 0.9em; display: flex; align-items: start; gap: 8px;">
 <span style="font-size: 1.2em;">⚠</span>
 <div>
-<$text text={{{ [<chinese>match[yes]then[当前选择的是服务器镜像，但该镜像暂时无法访问。评论、评分、统计和登录功能当前不可用。]else[The selected mirror is a server mirror, but it is currently unreachable. Comments, ratings, stats, and login are unavailable right now.]] }}}/>
+<$text text={{{ [<chinese>match[yes]then[当前配置的 CPL 服务器暂时不可访问。评论、评分、统计、更新日志和登录功能当前不可用，但数据库镜像仍可正常浏览。]else[The configured CPL server is currently unreachable. Comments, ratings, stats, changelog, and login are unavailable right now, but the database mirror can still be browsed normally.]] }}}/>
 </div>
 </div>
 </$list>

--- a/src/CPLPlugin/views/plugins/stats.tid
+++ b/src/CPLPlugin/views/plugins/stats.tid
@@ -16,31 +16,21 @@ type: text/vnd.tiddlywiki
 <!-- Plugin Stats Display -->
 <$list filter="[all[current]tag[$:/tags/PluginWiki]has[cpl.title]]" variable="pluginTiddler">
 
-<!-- Check if current mirror supports server features -->
-<$let mirrorType={{{ [[$:/temp/CPL-Repo/mirror-type]get[text]else[unknown]] }}}>
+<!-- Check if configured CPL server is available -->
+<$let serverType={{{ [[$:/temp/CPL-Repo/server-type]get[text]else[unknown]] }}} chinese={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[yes]else[no]] }}}>
 
-<!-- Static Mirror Notice -->
-<$list filter="[<mirrorType>match[static]]" variable="isStaticMirror">
-<div class="cpl-static-feature-notice" style="background: #fff3cd; border: 1px solid #ffc107; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
-<span style="font-size: 1.5em;">ℹ️</span>
-<div>
-<strong><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[服务器功能不可用]else[Server Features Unavailable]] }}}/></strong>
-<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[当前镜像为静态镜像，不支持下载统计、评分和更新日志功能。切换到服务器镜像以使用这些功能。]else[Current mirror is a static mirror. Download stats, ratings, and changelog are not available. Switch to a server mirror to access these features.]] }}}/></p>
-</div>
-</div>
-</$list>
-<$list filter="[<mirrorType>match[unreachable]]" variable="isUnavailableMirror">
+<$list filter="[<serverType>!match[server]]" variable="isUnavailableServer">
 <div class="cpl-static-feature-notice" style="background: #f8d7da; border: 1px solid #dc3545; border-radius: 6px; padding: 12px; margin: 10px 0; font-size: 0.9em; display: flex; align-items: start; gap: 10px;">
 <span style="font-size: 1.5em;">⚠️</span>
 <div>
-<strong><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[服务器镜像不可访问]else[Server Mirror Unreachable]] }}}/></strong>
-<p style="margin: 4px 0 0 0;"><$text text={{{ [[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[当前选择的是服务器镜像，但它暂时无法访问，因此下载统计、评分和更新日志功能当前不可用。]else[The selected mirror should provide server features, but it is currently unreachable, so download stats, ratings, and changelog are unavailable.]] }}}/></p>
+<strong><$text text={{{ [<chinese>match[yes]then[CPL 服务器当前不可用]else[CPL Server Unavailable]] }}}/></strong>
+<p style="margin: 4px 0 0 0;"><$text text={{{ [<chinese>match[yes]then[当前配置的 CPL 服务器暂时不可访问，因此评论、下载统计、评分、更新日志等联网功能当前不可用。你仍然可以浏览静态插件数据库。]else[The configured CPL server is currently unreachable, so comments, download stats, ratings, changelog, and other online features are unavailable right now. You can still browse the static plugin database.]] }}}/></p>
 </div>
 </div>
 </$list>
 
 <!-- Only show stats/rating/changelog for server mirrors -->
-<$list filter="[<mirrorType>match[server]]" variable="isServerMirror">
+<$list filter="[<serverType>match[server]]" variable="isServerMirror">
 
 <!-- Auto-fetch stats on render -->
 <$action-sendmessage $message="cpl-fetch-stats" pluginTitle={{!!cpl.title}} />

--- a/src/CPLPlugin/views/system/settings.tid
+++ b/src/CPLPlugin/views/system/settings.tid
@@ -18,12 +18,20 @@ type: text/vnd.tiddlywiki
 </$list>
 </$select>
 
+; CPL 服务器地址 <$select tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/current-server" field="text">
+<$list filter="[{$:/plugins/Gk0Wk/CPL-Repo/config/servers}enlist-input[]]" variable="server">
+<option value=<<server>>><$text text=<<server>>/></option>
+</$list>
+</$select>
+
 <<<
 当 CPL 获取数据经常失败时，你可以尝试切换到其他镜像，目前国内推荐使用 netlify 镜像，
 
 欢迎各位大佬部署国内镜像，详情请咨询QQ交流群或在[[GitHub Issue|https://github.com/tiddly-gittly/TiddlyWiki-CPL/issues]]提问
 
 你可以手动更改数据库镜像入口：[[$:/plugins/Gk0Wk/CPL-Repo/config/current-repo]]
+
+你也可以单独更改 CPL 服务器地址：[[$:/plugins/Gk0Wk/CPL-Repo/config/current-server]]
 <<<
 
 ; 自动更新检查间隔 <$edit-text tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-update-intervals-minutes" tag="input" default="-1" /> (分钟/次)
@@ -65,12 +73,20 @@ In this page you can set the behavior of the CPL plugin.
 </$list>
 </$select>
 
+; CPL Server Endpoint <$select tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/current-server" field="text">
+<$list filter="[{$:/plugins/Gk0Wk/CPL-Repo/config/servers}enlist-input[]]" variable="server">
+<option value=<<server>>><$text text=<<server>>/></option>
+</$list>
+</$select>
+
 <<<
 When the CPL fails to fetch the data often, you can try to switch to another mirror.
 
 If you'd like to deploy your own mirrors, feel free to ask questions in the [[GitHub Issue|https://github.com/tiddly-gittly/TiddlyWiki-CPL/issues]]!
 
 You can manually change the database mirror entry: [[$:/plugins/Gk0Wk/CPL-Repo/config/current-repo]]
+
+You can also configure the CPL server endpoint independently: [[$:/plugins/Gk0Wk/CPL-Repo/config/current-server]]
 <<<
 
 ; Automatic update of check intervals <$edit-text tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-update-intervals-minutes" tag="input" default="-1" /> (minute(s) per time)

--- a/tests/e2e/cpl-server.spec.js
+++ b/tests/e2e/cpl-server.spec.js
@@ -60,12 +60,14 @@ async function navigateToPlugin(page, tiddlerTitle) {
   await page.waitForFunction(() => typeof $tw !== 'undefined' && typeof $tw.wiki !== 'undefined', { timeout: 30000 });
   await page.waitForFunction(() => typeof $tw.cpl !== 'undefined', { timeout: 30000 });
 
-  // Use local server as mirror so API probing succeeds in test environment.
-  // External mirrors (e.g. netlify) may not have CORS or server API enabled,
-  // which would mark them as static and disable server-only features.
+  // Use the local test server as CPL server endpoint so API probing succeeds.
   await page.evaluate(() => {
     $tw.wiki.addTiddler({
       title: '$:/plugins/Gk0Wk/CPL-Repo/config/current-repo',
+      text: window.location.origin
+    });
+    $tw.wiki.addTiddler({
+      title: '$:/plugins/Gk0Wk/CPL-Repo/config/current-server',
       text: window.location.origin
     });
   });
@@ -100,6 +102,10 @@ async function installFromMirrorInBlankWiki(page, mirrorUrl, pluginTitle) {
     $tw.wiki.addTiddler({
       title: '$:/plugins/Gk0Wk/CPL-Repo/config/current-repo',
       text: mirrorUrl
+    });
+    $tw.wiki.addTiddler({
+      title: '$:/plugins/Gk0Wk/CPL-Repo/config/current-server',
+      text: window.location.origin
     });
   }, { mirrorUrl });
 
@@ -278,11 +284,11 @@ test.describe('CPL Server E2E', () => {
     expect(['server', 'static']).toContain(mirrorState.mirrorType);
   });
 
-  test('should degrade gracefully for static mirror capabilities while preserving mirror selector', async ({ page }) => {
+  test('should degrade gracefully when CPL server is unavailable while preserving mirror selector', async ({ page }) => {
     await navigateToPlugin(page, TEST_PLUGIN_TIDDLER);
 
     await page.evaluate(() => {
-      $tw.wiki.addTiddler({ title: '$:/temp/CPL-Repo/mirror-type', text: 'static' });
+      $tw.wiki.addTiddler({ title: '$:/temp/CPL-Repo/server-type', text: 'unreachable' });
       $tw.wiki.addTiddler({ title: '$:/temp/CPL-Repo/api-status', text: 'unavailable' });
     });
 


### PR DESCRIPTION
## Summary
- decouple the CPL API server endpoint from the selected plugin database mirror
- keep repo mirror classification for database browsing, but use a separate configurable CPL server endpoint for comments, stats, ratings, changelog, auth, and compatibility
- remove the duplicate plugin-page availability notices and keep the remaining notice on a single language-aware path

## Root cause
The frontend reused `$:/plugins/Gk0Wk/CPL-Repo/config/current-repo` for two different concerns:
1. which static/dynamic repo mirror to use for the plugin database
2. which origin to call for `/cpl/api/*`

That made static mirrors look like they could never use server features, even though a static page should still be able to call a separate CPL server.

## Validation
- pnpm run test:api
- pnpm run build:website
- runtime probe: static repo mirror + unreachable configured server => one notice only, in the active language
- runtime probe: static repo mirror + separate local server => `serverType=server`, no warning notice, stats/comments widgets visible