### PR TITLE
fix(cpl): stop homepage auto-install and keep auto-load in CPL layout

### DIFF
--- a/src/CPLPlugin/config/defaults.multids
+++ b/src/CPLPlugin/config/defaults.multids
@@ -7,4 +7,5 @@ server-repos: https://cpl.tidgi.fun/repo
 servers: https://cpl.tidgi.fun
 current-repo: https://tw-cpl.netlify.app/repo
 current-server: https://cpl.tidgi.fun
-auto-refresh-at-startup: yes
+auto-refresh-at-startup: no
+auto-load-database-in-cpl-layout: yes

--- a/src/CPLPlugin/layout/action-bar.tid
+++ b/src/CPLPlugin/layout/action-bar.tid
@@ -5,7 +5,7 @@ title: $:/plugins/Gk0Wk/CPL-Repo/layout/action-bar
 type: text/vnd.tiddlywiki
 
 <$list filter="[[$:/language]get[text]removeprefix[$:/languages/]else[en-GB]search[zh]then[yes]else[no]]" variable="chinese">
-<$let autoSyncEnabled={{{ [[$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup]get[text]else[yes]] }}}>
+<$let autoSyncEnabled={{{ [[$:/plugins/Gk0Wk/CPL-Repo/config/auto-load-database-in-cpl-layout]get[text]else[yes]] }}}>
 <div class="cpl-action-bar">
 <$button disabled={{{ [{$:/temp/CPL-Repo/getting-plugins-index}match[yes]else[no]] }}} class="tc-btn-big-green tc-primary-btn cpl-action-button">
 <$action-sendmessage $message="cpl-get-plugins-index" />
@@ -38,8 +38,8 @@ type: text/vnd.tiddlywiki
 </$list>
 
 <label class="cpl-action-toggle">
-<$checkbox tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup" field="text" checked="yes" unchecked="no" default="yes">
-<span class="cpl-action-toggle-label"><$text text={{{ [<chinese>match[yes]then[自动刷新并自动加载更新]else[Auto refresh and auto load updates]] }}} /></span>
+<$checkbox tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-load-database-in-cpl-layout" field="text" checked="yes" unchecked="no" default="yes">
+<span class="cpl-action-toggle-label"><$text text={{{ [<chinese>match[yes]then[进入 CPL 布局时自动加载数据库]else[Auto load the database when entering the CPL layout]] }}} /></span>
 </$checkbox>
 </label>
 

--- a/src/CPLPlugin/startup/core.ts
+++ b/src/CPLPlugin/startup/core.ts
@@ -24,10 +24,6 @@ export const startup = (): void => {
   let indexController: ReturnType<typeof createIndexController> | undefined;
 
   const triggerMirrorRefresh = (): void => {
-    tw.wiki.addTiddler({
-      title: '$:/temp/CPL-Repo/plugins-index-refresh-requested',
-      text: 'yes',
-    });
     tw.rootWidget.dispatchEvent({
       type: 'cpl-get-plugins-index',
       paramObject: {},
@@ -35,13 +31,11 @@ export const startup = (): void => {
     });
   };
 
-  const shouldAutoRefreshOnStartup = (): boolean =>
+  const shouldAutoLoadDatabaseInCplLayout = (): boolean =>
     tw.wiki.getTiddlerText(
-      '$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup',
+      '$:/plugins/Gk0Wk/CPL-Repo/config/auto-load-database-in-cpl-layout',
       'yes',
     ) !== 'no';
-
-  let initialAutoSyncPending = shouldAutoRefreshOnStartup();
 
   const mirrorController = createMirrorController({
     isBusy: () =>
@@ -55,10 +49,6 @@ export const startup = (): void => {
   indexController = createIndexController({
     onIndexLoaded: () => {
       mirrorController.completePendingSwitch();
-      if (initialAutoSyncPending) {
-        initialAutoSyncPending = false;
-        void updateController.update({ notify: false, autoInstall: true });
-      }
     },
     onIndexLoadFailed: mirrorController.failPendingSwitch,
   });
@@ -80,15 +70,11 @@ export const startup = (): void => {
       updateController.rescheduleAutoUpdate();
     }
 
-    if (tw.utils.hop(changes, '$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup')) {
-      initialAutoSyncPending = shouldAutoRefreshOnStartup();
-    }
-
-    // Auto-load database when switching to CPL layout
     if (tw.utils.hop(changes, '$:/layout')) {
       const currentLayout = tw.wiki.getTiddlerText('$:/layout', '');
       if (
         currentLayout === '$:/plugins/Gk0Wk/CPL-Repo/layout/layout'
+        && shouldAutoLoadDatabaseInCplLayout()
         && !tw.wiki.tiddlerExists('$:/temp/CPL-Repo/plugins-index')
         && indexController
         && !indexController.isBusy()
@@ -122,14 +108,6 @@ export const startup = (): void => {
   });
 
   updateController.initializeAutoUpdate();
-
-  if (initialAutoSyncPending) {
-    setTimeout(() => {
-      if (shouldAutoRefreshOnStartup()) {
-        triggerMirrorRefresh();
-      }
-    }, 1500);
-  }
 
   tw.rootWidget.addEventListener('cpl-update-check', (_event: RootWidgetEvent): undefined => {
     void updateController.update();

--- a/src/CPLPlugin/views/system/settings.tid
+++ b/src/CPLPlugin/views/system/settings.tid
@@ -47,12 +47,12 @@ type: text/vnd.tiddlywiki
 <<<
 
 <$checkbox
-  tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup"
+  tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-load-database-in-cpl-layout"
   field="text"
   checked="yes"
   unchecked="no"
   default="yes">
-  启动时自动刷新数据库并自动安装可更新插件
+  进入 CPL 布局时自动加载数据库
 </$checkbox>
 
 ; 插件更新筛选器 <$edit-text tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/update-filter" tag="input" default="" />
@@ -102,12 +102,12 @@ After closing it can be checked manually in [CPL] of [[$:/ControlPanel]].
 <<<
 
 <$checkbox
-  tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-refresh-at-startup"
+  tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/auto-load-database-in-cpl-layout"
   field="text"
   checked="yes"
   unchecked="no"
   default="yes">
-  Automatically refresh the database and install available updates on startup
+  Automatically load the database when entering the CPL layout
 </$checkbox>
 
 ; Plugin Update Filter <$edit-text tiddler="$:/plugins/Gk0Wk/CPL-Repo/config/update-filter" tag="input" default="" />


### PR DESCRIPTION
## Summary
- stop the static homepage from auto-refreshing the plugin index and auto-installing updates on load
- keep automatic database loading scoped to entering the CPL layout instead of the homepage
- move the user-facing CPL auto-load setting to a layout-specific config tiddler

## Root cause
The shipped static site was still honoring the legacy `auto-refresh-at-startup` flag on load. On the published homepage that caused CPL to fetch the plugin index immediately and then auto-install update candidates, which surfaced as download notifications and a plugin reload warning.

## What changed
- default the legacy startup flag to `no` so the homepage no longer triggers the old startup path
- use a dedicated `auto-load-database-in-cpl-layout` setting for the intended CPL-layout behavior
- keep the actual CPL-layout auto-load on the layout-change listener, not homepage startup
- update the CPL settings/action bar labels to match the new behavior

## Validation
- `pnpm run build:static-site`
- local browser probe on rebuilt static site:
  - homepage stays idle for 7s with no auto-download/install
  - entering CPL layout loads the plugin index automatically