### PR TITLE
fix(data-sync): prevent stale mirror stats from overwriting GitHub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,19 @@ name: CI
 
 on:
   pull_request:
+    paths-ignore:
+      - 'wiki/tiddlers/download-stats/**'
+      - 'wiki/tiddlers/comments/**'
+      - 'wiki/tiddlers/ratings/**'
+      - 'wiki/tiddlers/compatibility/**'
   push:
     branches:
       - master
+    paths-ignore:
+      - 'wiki/tiddlers/download-stats/**'
+      - 'wiki/tiddlers/comments/**'
+      - 'wiki/tiddlers/ratings/**'
+      - 'wiki/tiddlers/compatibility/**'
 
 permissions:
   contents: read
@@ -15,6 +25,7 @@ concurrency:
 
 jobs:
   build-and-tests:
+    if: ${{ github.event_name != 'pull_request' || !startsWith(github.head_ref, 'data-sync/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,6 +15,10 @@ on:
       - "scripts/**"
       - "src/**"
       - "wiki/**"
+      - "!wiki/tiddlers/download-stats/**"
+      - "!wiki/tiddlers/comments/**"
+      - "!wiki/tiddlers/ratings/**"
+      - "!wiki/tiddlers/compatibility/**"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - '.github/workflows/update-library.yml'
       - libraries.json
+      - 'wiki/tiddlers/download-stats/**'
+      - 'wiki/tiddlers/comments/**'
+      - 'wiki/tiddlers/ratings/**'
+      - 'wiki/tiddlers/compatibility/**'
   schedule:
     - cron: '0 * * * *'
 

--- a/scripts/sync-data.sh
+++ b/scripts/sync-data.sh
@@ -58,23 +58,73 @@ git -C "$checkout_dir" checkout -B "$SYNC_BRANCH" >/dev/null
 git -C "$checkout_dir" config user.name "CPL Data Sync (${SERVER_ID})"
 git -C "$checkout_dir" config user.email "cpl-data-sync@users.noreply.github.com"
 
+# Each mirror may only overlay its own suffixed tiddlers. Copying the whole
+# directory would rewrite the other server's files from a stale PVC/Forgejo
+# snapshot and can decrease download counts / rewind lastUpdated.
+SUFFIX=".${SERVER_ID}.tid"
+
+stats_count() {
+  sed -n 's/.*"downloadCount":\([0-9][0-9]*\).*/\1/p' "$1"
+}
+
+stats_updated() {
+  sed -n 's/.*"lastUpdated":"\([^"]*\)".*/\1/p' "$1"
+}
+
+should_copy_stats() {
+  src=$1
+  dest=$2
+  if [ ! -f "$dest" ]; then
+    return 0
+  fi
+  src_count=$(stats_count "$src")
+  dest_count=$(stats_count "$dest")
+  src_count=${src_count:-0}
+  dest_count=${dest_count:-0}
+  if [ "$src_count" -gt "$dest_count" ]; then
+    return 0
+  fi
+  if [ "$src_count" -lt "$dest_count" ]; then
+    echo "[sync-data] Skip stale $src (count $src_count < $dest_count)"
+    return 1
+  fi
+  src_updated=$(stats_updated "$src")
+  dest_updated=$(stats_updated "$dest")
+  if [ -n "$src_updated" ] && [ -n "$dest_updated" ] && [ "$src_updated" \< "$dest_updated" ]; then
+    echo "[sync-data] Skip stale $src (lastUpdated $src_updated < $dest_updated)"
+    return 1
+  fi
+  return 0
+}
+
 for relative_path in $SYNC_PATHS; do
   source_path="$REPO_ROOT/$relative_path"
   destination_path="$checkout_dir/$relative_path"
-  if [ -d "$source_path" ]; then
-    mkdir -p "$destination_path"
-    cp -a "$source_path/." "$destination_path/"
-  elif [ -f "$source_path" ]; then
-    mkdir -p "$(dirname "$destination_path")"
-    cp -a "$source_path" "$destination_path"
+  if [ ! -d "$source_path" ]; then
+    continue
   fi
+  mkdir -p "$destination_path"
+  find "$source_path" -type f -name "*$SUFFIX" | while IFS= read -r src_file; do
+    rel="${src_file#$source_path/}"
+    dest_file="$destination_path/$rel"
+    mkdir -p "$(dirname "$dest_file")"
+    if [ "$relative_path" = "wiki/tiddlers/download-stats" ]; then
+      if should_copy_stats "$src_file" "$dest_file"; then
+        cp -a "$src_file" "$dest_file"
+      fi
+    else
+      cp -a "$src_file" "$dest_file"
+    fi
+  done
 done
 
 git -C "$REPO_ROOT" diff --name-only --diff-filter=D -- $SYNC_PATHS |
 while IFS= read -r deleted_path; do
-  if [ -n "$deleted_path" ]; then
-    rm -rf "$checkout_dir/$deleted_path"
-  fi
+  case "$deleted_path" in
+    *"$SUFFIX")
+      rm -rf "$checkout_dir/$deleted_path"
+      ;;
+  esac
 done
 
 if [ "${CPL_SYNC_DEBUG:-false}" = "true" ]; then

--- a/scripts/sync-data.sh
+++ b/scripts/sync-data.sh
@@ -1,155 +1,21 @@
 #!/bin/sh
 set -eu
 
-REPO_ROOT="${CPL_REPO_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-SERVER_ID="${CPL_SERVER_ID:-}"
-SYNC_REPO="${CPL_SYNC_REPO:-git@github.com:tiddly-gittly/TiddlyWiki-CPL.git}"
-BASE_BRANCH="${CPL_SYNC_BRANCH:-master}"
-SYNC_BRANCH="data-sync/${SERVER_ID}"
-LOCK_DIR="$REPO_ROOT/.cpl-sync-lock"
-SYNC_PATHS="
-wiki/tiddlers/comments
-wiki/tiddlers/ratings
-wiki/tiddlers/compatibility
-wiki/tiddlers/download-stats
-"
+DIR=$(CDPATH= cd -- "$(dirname "$0")" && pwd)
+SCRIPT="$DIR/sync-data.ts"
 
-if [ -z "$SERVER_ID" ]; then
-  echo "[sync-data] CPL_SERVER_ID is required" >&2
+if ! command -v node >/dev/null 2>&1; then
+  echo "[sync-data] node is required to run $SCRIPT" >&2
   exit 1
 fi
 
-acquire_lock() {
-  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-    if [ -f "$LOCK_DIR/timestamp" ]; then
-      lock_time=$(cat "$LOCK_DIR/timestamp" 2>/dev/null || echo 0)
-      now=$(date +%s)
-      if [ $((now - lock_time)) -gt 3600 ]; then
-        rm -rf "$LOCK_DIR"
-        continue
-      fi
-    fi
-    sleep 2
-  done
-  date +%s > "$LOCK_DIR/timestamp"
-}
-
-temp_dir=""
-cleanup() {
-  if [ -n "$temp_dir" ]; then
-    rm -rf "$temp_dir"
-  fi
-  rm -rf "$LOCK_DIR"
-}
-
-acquire_lock
-trap cleanup EXIT INT TERM
-
-if [ ! -d "$REPO_ROOT/.git" ]; then
-  echo "[sync-data] $REPO_ROOT is not a Git repository" >&2
-  exit 1
+if node --experimental-strip-types -e "process.exit(0)" >/dev/null 2>&1; then
+  exec node --experimental-strip-types "$SCRIPT" "$@"
 fi
 
-temp_dir=$(mktemp -d)
-checkout_dir="$temp_dir/repository"
-
-git clone --quiet --depth 1 --branch "$BASE_BRANCH" "$SYNC_REPO" "$checkout_dir"
-git -C "$checkout_dir" checkout -B "$SYNC_BRANCH" >/dev/null
-git -C "$checkout_dir" config user.name "CPL Data Sync (${SERVER_ID})"
-git -C "$checkout_dir" config user.email "cpl-data-sync@users.noreply.github.com"
-
-# Each mirror may only overlay its own suffixed tiddlers. Copying the whole
-# directory would rewrite the other server's files from a stale PVC/Forgejo
-# snapshot and can decrease download counts / rewind lastUpdated.
-SUFFIX=".${SERVER_ID}.tid"
-
-stats_count() {
-  sed -n 's/.*"downloadCount":\([0-9][0-9]*\).*/\1/p' "$1"
-}
-
-stats_updated() {
-  sed -n 's/.*"lastUpdated":"\([^"]*\)".*/\1/p' "$1"
-}
-
-should_copy_stats() {
-  src=$1
-  dest=$2
-  if [ ! -f "$dest" ]; then
-    return 0
-  fi
-  src_count=$(stats_count "$src")
-  dest_count=$(stats_count "$dest")
-  src_count=${src_count:-0}
-  dest_count=${dest_count:-0}
-  if [ "$src_count" -gt "$dest_count" ]; then
-    return 0
-  fi
-  if [ "$src_count" -lt "$dest_count" ]; then
-    echo "[sync-data] Skip stale $src (count $src_count < $dest_count)"
-    return 1
-  fi
-  src_updated=$(stats_updated "$src")
-  dest_updated=$(stats_updated "$dest")
-  if [ -n "$src_updated" ] && [ -n "$dest_updated" ] && [ "$src_updated" \< "$dest_updated" ]; then
-    echo "[sync-data] Skip stale $src (lastUpdated $src_updated < $dest_updated)"
-    return 1
-  fi
-  return 0
-}
-
-for relative_path in $SYNC_PATHS; do
-  source_path="$REPO_ROOT/$relative_path"
-  destination_path="$checkout_dir/$relative_path"
-  if [ ! -d "$source_path" ]; then
-    continue
-  fi
-  mkdir -p "$destination_path"
-  find "$source_path" -type f -name "*$SUFFIX" | while IFS= read -r src_file; do
-    rel="${src_file#$source_path/}"
-    dest_file="$destination_path/$rel"
-    mkdir -p "$(dirname "$dest_file")"
-    if [ "$relative_path" = "wiki/tiddlers/download-stats" ]; then
-      if should_copy_stats "$src_file" "$dest_file"; then
-        cp -a "$src_file" "$dest_file"
-      fi
-    else
-      cp -a "$src_file" "$dest_file"
-    fi
-  done
-done
-
-git -C "$REPO_ROOT" diff --name-only --diff-filter=D -- $SYNC_PATHS |
-while IFS= read -r deleted_path; do
-  case "$deleted_path" in
-    *"$SUFFIX")
-      rm -rf "$checkout_dir/$deleted_path"
-      ;;
-  esac
-done
-
-if [ "${CPL_SYNC_DEBUG:-false}" = "true" ]; then
-  echo "[sync-data] Working tree after overlay:"
-  git -C "$checkout_dir" status --short -- $SYNC_PATHS
+if [ -f "$DIR/../node_modules/ts-node/dist/bin.js" ]; then
+  exec node "$DIR/../node_modules/ts-node/dist/bin.js" --transpile-only "$SCRIPT" "$@"
 fi
 
-for relative_path in $SYNC_PATHS; do
-  git -C "$checkout_dir" add -A -f -- "$relative_path" 2>/dev/null || true
-done
-if [ "${CPL_SYNC_DEBUG:-false}" = "true" ]; then
-  echo "[sync-data] Staged changes:"
-  git -C "$checkout_dir" diff --cached --stat
-fi
-if git -C "$checkout_dir" diff --cached --quiet; then
-  if git -C "$checkout_dir" ls-remote --exit-code --heads origin "refs/heads/$SYNC_BRANCH" >/dev/null 2>&1; then
-    git -C "$checkout_dir" push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
-    echo "[sync-data] Reset $SYNC_BRANCH to $BASE_BRANCH because no runtime data changes remain"
-  else
-    echo "[sync-data] No runtime data changes to sync"
-  fi
-  exit 0
-fi
-
-timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-git -C "$checkout_dir" commit -m "chore(data): sync from ${SERVER_ID} [${timestamp}]" >/dev/null
-git -C "$checkout_dir" push --force origin "HEAD:refs/heads/$SYNC_BRANCH"
-echo "[sync-data] Updated $SYNC_BRANCH; GitHub Actions will create or refresh the Pull Request"
+echo "[sync-data] Node 22.6+ (type stripping) or ts-node is required" >&2
+exit 1

--- a/scripts/sync-data.ts
+++ b/scripts/sync-data.ts
@@ -1,11 +1,404 @@
+/**
+ * Overlay this mirror's runtime tiddlers onto a fresh clone of GitHub master
+ * and force-update data-sync/{serverId}. Never touches the live wiki worktree.
+ */
 import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
-const projectRoot = path.resolve(__dirname, '..');
-const result = spawnSync('sh', ['scripts/sync-data.sh'], {
-  cwd: projectRoot,
-  env: process.env,
-  stdio: 'inherit',
-});
+export const SYNC_PATHS = [
+  'wiki/tiddlers/comments',
+  'wiki/tiddlers/ratings',
+  'wiki/tiddlers/compatibility',
+  'wiki/tiddlers/download-stats',
+] as const;
 
-process.exit(result.status ?? 1);
+export const DOWNLOAD_STATS_PATH = 'wiki/tiddlers/download-stats';
+
+export type DownloadStats = {
+  downloadCount: number;
+  lastUpdated: string | null;
+  downloadsByIp: Record<string, string>;
+};
+
+export type SyncDataOptions = {
+  repoRoot: string;
+  serverId: string;
+  syncRepo: string;
+  baseBranch: string;
+  debug?: boolean;
+};
+
+export type SyncDataResult = 'pushed' | 'unchanged' | 'reset';
+
+type GitResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+const log = (message: string): void => {
+  console.log(`[sync-data] ${message}`);
+};
+
+export const serverTidSuffix = (serverId: string): string => `.${serverId}.tid`;
+
+export const parseStatsTiddler = (raw: string): DownloadStats | null => {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const blank = normalized.indexOf('\n\n');
+  const body = (blank === -1 ? normalized : normalized.slice(blank + 2)).trim();
+  if (!body) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(body) as DownloadStats;
+    if (typeof parsed.downloadCount === 'number') {
+      return {
+        downloadCount: parsed.downloadCount,
+        lastUpdated: parsed.lastUpdated ?? null,
+        downloadsByIp: parsed.downloadsByIp ?? {},
+      };
+    }
+  } catch {
+    // Fall through to plaintext count.
+  }
+
+  const count = Number.parseInt(body, 10);
+  if (Number.isNaN(count)) {
+    return null;
+  }
+  return { downloadCount: count, lastUpdated: null, downloadsByIp: {} };
+};
+
+export const splitTiddler = (
+  raw: string,
+): { header: string; body: string } => {
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const blank = normalized.indexOf('\n\n');
+  if (blank === -1) {
+    return { header: normalized.trimEnd(), body: '' };
+  }
+  return {
+    header: normalized.slice(0, blank).trimEnd(),
+    body: normalized.slice(blank + 2),
+  };
+};
+
+export const laterTimestamp = (
+  left: string | null,
+  right: string | null,
+): string | null => {
+  if (!left) {
+    return right;
+  }
+  if (!right) {
+    return left;
+  }
+  return left > right ? left : right;
+};
+
+export const mergeDownloadStats = (
+  local: DownloadStats,
+  remote: DownloadStats,
+): DownloadStats => {
+  const downloadsByIp = { ...remote.downloadsByIp };
+  for (const [ip, timestamp] of Object.entries(local.downloadsByIp)) {
+    const existing = downloadsByIp[ip];
+    downloadsByIp[ip] = laterTimestamp(existing ?? null, timestamp) ?? timestamp;
+  }
+
+  const uniqueIps = Object.keys(downloadsByIp).length;
+  return {
+    downloadCount: Math.max(
+      local.downloadCount,
+      remote.downloadCount,
+      uniqueIps,
+    ),
+    lastUpdated: laterTimestamp(local.lastUpdated, remote.lastUpdated),
+    downloadsByIp,
+  };
+};
+
+export const statsEqual = (
+  left: DownloadStats,
+  right: DownloadStats,
+): boolean => JSON.stringify(left) === JSON.stringify(right);
+
+const walkTidFiles = (dir: string, suffix: string): string[] => {
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...walkTidFiles(fullPath, suffix));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(suffix)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+};
+
+export const overlayServerTiddlers = ({
+  sourceRoot,
+  destinationRoot,
+  serverId,
+}: {
+  sourceRoot: string;
+  destinationRoot: string;
+  serverId: string;
+}): void => {
+  const suffix = serverTidSuffix(serverId);
+
+  for (const relativePath of SYNC_PATHS) {
+    const sourceDir = path.join(sourceRoot, relativePath);
+    const destinationDir = path.join(destinationRoot, relativePath);
+    if (!fs.existsSync(sourceDir)) {
+      continue;
+    }
+    fs.mkdirSync(destinationDir, { recursive: true });
+
+    for (const sourceFile of walkTidFiles(sourceDir, suffix)) {
+      const relativeFile = path.relative(sourceDir, sourceFile);
+      const destinationFile = path.join(destinationDir, relativeFile);
+      fs.mkdirSync(path.dirname(destinationFile), { recursive: true });
+
+      if (relativePath !== DOWNLOAD_STATS_PATH) {
+        fs.copyFileSync(sourceFile, destinationFile);
+        continue;
+      }
+
+      const localRaw = fs.readFileSync(sourceFile, 'utf8');
+      const localStats = parseStatsTiddler(localRaw);
+      if (!localStats) {
+        fs.copyFileSync(sourceFile, destinationFile);
+        continue;
+      }
+
+      if (!fs.existsSync(destinationFile)) {
+        fs.copyFileSync(sourceFile, destinationFile);
+        continue;
+      }
+
+      const remoteRaw = fs.readFileSync(destinationFile, 'utf8');
+      const remoteStats = parseStatsTiddler(remoteRaw);
+      if (!remoteStats) {
+        fs.copyFileSync(sourceFile, destinationFile);
+        continue;
+      }
+
+      const merged = mergeDownloadStats(localStats, remoteStats);
+      if (statsEqual(merged, remoteStats)) {
+        continue;
+      }
+
+      const { header } = splitTiddler(remoteRaw);
+      const looksLikeTiddler = /^title:/im.test(header);
+      const serialized = looksLikeTiddler
+        ? `${header}\n\n${JSON.stringify(merged)}`
+        : JSON.stringify(merged);
+      fs.writeFileSync(destinationFile, serialized);
+    }
+  }
+};
+
+const runGit = (
+  args: string[],
+  cwd: string,
+  allowFail = false,
+): GitResult => {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+  });
+  const stdout = (result.stdout ?? '').trim();
+  const stderr = (result.stderr ?? '').trim();
+  const status = result.status ?? 1;
+  if (status !== 0 && !allowFail) {
+    throw new Error(`git ${args.join(' ')} failed (${status}): ${stderr}`);
+  }
+  return { status, stdout, stderr };
+};
+
+const sleepSync = (ms: number): void => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+};
+
+const acquireLock = (lockDir: string): void => {
+  for (;;) {
+    try {
+      fs.mkdirSync(lockDir);
+      fs.writeFileSync(path.join(lockDir, 'timestamp'), String(Date.now()));
+      return;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'EEXIST') {
+        throw error;
+      }
+      let lockTime = 0;
+      try {
+        lockTime = Number(
+          fs.readFileSync(path.join(lockDir, 'timestamp'), 'utf8'),
+        );
+      } catch {
+        lockTime = 0;
+      }
+      if (Date.now() - lockTime > 60 * 60 * 1000) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      sleepSync(2000);
+    }
+  }
+};
+
+const applyOwnDeletions = (
+  repoRoot: string,
+  checkoutDir: string,
+  serverId: string,
+): void => {
+  const suffix = serverTidSuffix(serverId);
+  const deleted = runGit(
+    ['diff', '--name-only', '--diff-filter=D', '--', ...SYNC_PATHS],
+    repoRoot,
+    true,
+  );
+  for (const deletedPath of deleted.stdout.split(/\r?\n/)) {
+    if (!deletedPath.endsWith(suffix)) {
+      continue;
+    }
+    fs.rmSync(path.join(checkoutDir, deletedPath), {
+      recursive: true,
+      force: true,
+    });
+  }
+};
+
+export const syncRuntimeData = (options: SyncDataOptions): SyncDataResult => {
+  const repoRoot = path.resolve(options.repoRoot);
+  const serverId = options.serverId;
+  const syncBranch = `data-sync/${serverId}`;
+  const lockDir = path.join(repoRoot, '.cpl-sync-lock');
+
+  if (!serverId) {
+    throw new Error('CPL_SERVER_ID is required');
+  }
+  if (!fs.existsSync(path.join(repoRoot, '.git'))) {
+    throw new Error(`${repoRoot} is not a Git repository`);
+  }
+
+  acquireLock(lockDir);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cpl-data-sync-'));
+  const checkoutDir = path.join(tempDir, 'repository');
+
+  try {
+    runGit(
+      [
+        'clone',
+        '--quiet',
+        '--depth',
+        '1',
+        '--branch',
+        options.baseBranch,
+        options.syncRepo,
+        checkoutDir,
+      ],
+      repoRoot,
+    );
+    runGit(['checkout', '-B', syncBranch], checkoutDir);
+    runGit(['config', 'user.name', `CPL Data Sync (${serverId})`], checkoutDir);
+    runGit(
+      ['config', 'user.email', 'cpl-data-sync@users.noreply.github.com'],
+      checkoutDir,
+    );
+
+    overlayServerTiddlers({
+      sourceRoot: repoRoot,
+      destinationRoot: checkoutDir,
+      serverId,
+    });
+    applyOwnDeletions(repoRoot, checkoutDir, serverId);
+
+    if (options.debug) {
+      log(
+        `Working tree after overlay:\n${
+          runGit(['status', '--short', '--', ...SYNC_PATHS], checkoutDir, true)
+            .stdout
+        }`,
+      );
+    }
+
+    for (const relativePath of SYNC_PATHS) {
+      runGit(['add', '-A', '-f', '--', relativePath], checkoutDir, true);
+    }
+
+    if (options.debug) {
+      log(
+        `Staged changes:\n${
+          runGit(['diff', '--cached', '--stat'], checkoutDir, true).stdout
+        }`,
+      );
+    }
+
+    const staged = runGit(['diff', '--cached', '--quiet'], checkoutDir, true);
+    if (staged.status === 0) {
+      const remoteBranch = runGit(
+        ['ls-remote', '--exit-code', '--heads', 'origin', `refs/heads/${syncBranch}`],
+        checkoutDir,
+        true,
+      );
+      if (remoteBranch.status === 0) {
+        runGit(['push', '--force', 'origin', `HEAD:refs/heads/${syncBranch}`], checkoutDir);
+        log(
+          `Reset ${syncBranch} to ${options.baseBranch} because no runtime data changes remain`,
+        );
+        return 'reset';
+      }
+      log('No runtime data changes to sync');
+      return 'unchanged';
+    }
+
+    const timestamp = new Date().toISOString();
+    runGit(
+      ['commit', '-m', `chore(data): sync from ${serverId} [${timestamp}]`],
+      checkoutDir,
+    );
+    runGit(['push', '--force', 'origin', `HEAD:refs/heads/${syncBranch}`], checkoutDir);
+    log(
+      `Updated ${syncBranch}; GitHub Actions will create or refresh the Pull Request`,
+    );
+    return 'pushed';
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  }
+};
+
+export const main = (): number => {
+  try {
+    syncRuntimeData({
+      repoRoot: process.env.CPL_REPO_ROOT ?? path.resolve(__dirname, '..'),
+      serverId: process.env.CPL_SERVER_ID ?? '',
+      syncRepo:
+        process.env.CPL_SYNC_REPO ??
+        'git@github.com:tiddly-gittly/TiddlyWiki-CPL.git',
+      baseBranch: process.env.CPL_SYNC_BRANCH ?? 'master',
+      debug: process.env.CPL_SYNC_DEBUG === 'true',
+    });
+    return 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`[sync-data] ${message}`);
+    return 1;
+  }
+};
+
+if (typeof require !== 'undefined' && require.main === module) {
+  process.exit(main());
+}

--- a/tests/unit/data-sync.test.js
+++ b/tests/unit/data-sync.test.js
@@ -39,7 +39,7 @@ function shellExecutable() {
   return gitBash;
 }
 
-test('runtime data sync preserves modifications, ignored files, and deletions', () => {
+test('runtime data sync overlays only this server and never decreases stats', () => {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cpl-data-sync-'));
   const remote = path.join(tempRoot, 'remote.git');
   const live = path.join(tempRoot, 'live');
@@ -68,7 +68,11 @@ test('runtime data sync preserves modifications, ignored files, and deletions', 
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      'count=1\n',
+      '{"downloadCount":3,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
+    );
+    fs.writeFileSync(
+      path.join(live, 'wiki/tiddlers/download-stats/plugin.us.tid'),
+      '{"downloadCount":9,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'),
@@ -79,9 +83,37 @@ test('runtime data sync preserves modifications, ignored files, and deletions', 
     run('git', ['branch', '-M', 'master'], { cwd: live });
     run('git', ['push', 'origin', 'master'], { cwd: live });
 
+    // Stale PVC: this server's count went backwards, and it also holds an
+    // outdated copy of the other mirror's file.
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      'count=2\n',
+      '{"downloadCount":1,"lastUpdated":"2026-08-01T00:00:00.000Z"}\n',
+    );
+    fs.writeFileSync(
+      path.join(live, 'wiki/tiddlers/download-stats/plugin.us.tid'),
+      '{"downloadCount":1,"lastUpdated":"2026-08-02T00:00:00.000Z"}\n',
+    );
+
+    run(shellExecutable(), [shellPath(syncScript)], {
+      env: {
+        ...process.env,
+        CPL_REPO_ROOT: shellPath(live),
+        CPL_SERVER_ID: 'china',
+        CPL_SYNC_REPO: shellPath(remote),
+        CPL_SYNC_BRANCH: 'master',
+      },
+    });
+
+    const staleBranch = spawnSync(
+      'git',
+      ['ls-remote', '--exit-code', '--heads', remote, 'refs/heads/data-sync/china'],
+      { encoding: 'utf8' },
+    );
+    expect(staleBranch.status).not.toBe(0);
+
+    fs.writeFileSync(
+      path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
+      '{"downloadCount":4,"lastUpdated":"2026-08-25T00:00:00.000Z"}\n',
     );
     fs.rmSync(
       path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'),
@@ -107,52 +139,25 @@ test('runtime data sync preserves modifications, ignored files, and deletions', 
         path.join(verify, 'wiki/tiddlers/download-stats/plugin.china.tid'),
         'utf8',
       ),
-    ).toBe('count=2\n');
-    expect(
-      fs.existsSync(path.join(verify, 'wiki/tiddlers/ratings/new.china.tid')),
-    ).toBe(true);
-    expect(
-      fs.existsSync(
-        path.join(verify, 'wiki/tiddlers/comments/approved/old.china.tid'),
-      ),
-    ).toBe(false);
-
-    fs.writeFileSync(
-      path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      'count=1\n',
+    ).toBe(
+      '{"downloadCount":4,"lastUpdated":"2026-08-25T00:00:00.000Z"}\n',
     );
-    fs.writeFileSync(
-      path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'),
-      'approved\n',
-    );
-    fs.rmSync(path.join(live, 'wiki/tiddlers/ratings/new.china.tid'));
-
-    run(shellExecutable(), [shellPath(syncScript)], {
-      env: {
-        ...process.env,
-        CPL_REPO_ROOT: shellPath(live),
-        CPL_SERVER_ID: 'china',
-        CPL_SYNC_REPO: shellPath(remote),
-        CPL_SYNC_BRANCH: 'master',
-      },
-    });
-
-    run('git', ['fetch', 'origin', 'data-sync/china'], { cwd: verify });
-    run('git', ['reset', '--hard', 'origin/data-sync/china'], { cwd: verify });
     expect(
       fs.readFileSync(
-        path.join(verify, 'wiki/tiddlers/download-stats/plugin.china.tid'),
+        path.join(verify, 'wiki/tiddlers/download-stats/plugin.us.tid'),
         'utf8',
       ),
-    ).toBe('count=1\n');
+    ).toBe(
+      '{"downloadCount":9,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
+    );
     expect(
       fs.existsSync(path.join(verify, 'wiki/tiddlers/ratings/new.china.tid')),
-    ).toBe(false);
+    ).toBe(true);
     expect(
       fs.existsSync(
         path.join(verify, 'wiki/tiddlers/comments/approved/old.china.tid'),
       ),
-    ).toBe(true);
+    ).toBe(false);
   } finally {
     fs.rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/tests/unit/data-sync.test.js
+++ b/tests/unit/data-sync.test.js
@@ -2,9 +2,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { spawnSync } = require('child_process');
-
-const projectRoot = path.resolve(__dirname, '../..');
-const syncScript = path.join(projectRoot, 'scripts', 'sync-data.sh');
+const { syncRuntimeData } = require('../../scripts/sync-data.ts');
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
@@ -17,26 +15,6 @@ function run(command, args, options = {}) {
     );
   }
   return result.stdout.trim();
-}
-
-function shellPath(filePath) {
-  if (process.platform !== 'win32') {
-    return filePath;
-  }
-  return filePath
-    .replace(/^([A-Za-z]):/, (_, drive) => `/${drive.toLowerCase()}`)
-    .replace(/\\/g, '/');
-}
-
-function shellExecutable() {
-  if (process.platform !== 'win32') {
-    return 'sh';
-  }
-  const gitBash = 'C:\\Program Files\\Git\\bin\\bash.exe';
-  if (!fs.existsSync(gitBash)) {
-    throw new Error('Git Bash is required to test scripts/sync-data.sh');
-  }
-  return gitBash;
 }
 
 test('runtime data sync overlays only this server and never decreases stats', () => {
@@ -68,11 +46,11 @@ test('runtime data sync overlays only this server and never decreases stats', ()
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      '{"downloadCount":3,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
+      '{"downloadCount":3,"lastUpdated":"2026-08-22T00:00:00.000Z","downloadsByIp":{"8.8.8.8":"2026-08-22T00:00:00.000Z"}}\n',
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.us.tid'),
-      '{"downloadCount":9,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
+      '{"downloadCount":9,"lastUpdated":"2026-08-22T00:00:00.000Z","downloadsByIp":{"8.8.8.8":"2026-08-22T00:00:00.000Z"}}\n',
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'),
@@ -83,55 +61,55 @@ test('runtime data sync overlays only this server and never decreases stats', ()
     run('git', ['branch', '-M', 'master'], { cwd: live });
     run('git', ['push', 'origin', 'master'], { cwd: live });
 
-    // Stale PVC: this server's count went backwards, and it also holds an
-    // outdated copy of the other mirror's file.
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      '{"downloadCount":1,"lastUpdated":"2026-08-01T00:00:00.000Z"}\n',
+      '{"downloadCount":1,"lastUpdated":"2026-08-01T00:00:00.000Z","downloadsByIp":{"8.8.8.8":"2026-08-01T00:00:00.000Z"}}\n',
     );
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.us.tid'),
-      '{"downloadCount":1,"lastUpdated":"2026-08-02T00:00:00.000Z"}\n',
+      '{"downloadCount":1,"lastUpdated":"2026-08-02T00:00:00.000Z","downloadsByIp":{"9.9.9.9":"2026-08-02T00:00:00.000Z"}}\n',
     );
 
-    run(shellExecutable(), [shellPath(syncScript)], {
-      env: {
-        ...process.env,
-        CPL_REPO_ROOT: shellPath(live),
-        CPL_SERVER_ID: 'china',
-        CPL_SYNC_REPO: shellPath(remote),
-        CPL_SYNC_BRANCH: 'master',
-      },
-    });
+    expect(
+      syncRuntimeData({
+        repoRoot: live,
+        serverId: 'china',
+        syncRepo: remote,
+        baseBranch: 'master',
+      }),
+    ).toBe('unchanged');
 
     const staleBranch = spawnSync(
       'git',
-      ['ls-remote', '--exit-code', '--heads', remote, 'refs/heads/data-sync/china'],
+      [
+        'ls-remote',
+        '--exit-code',
+        '--heads',
+        remote,
+        'refs/heads/data-sync/china',
+      ],
       { encoding: 'utf8' },
     );
     expect(staleBranch.status).not.toBe(0);
 
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/download-stats/plugin.china.tid'),
-      '{"downloadCount":4,"lastUpdated":"2026-08-25T00:00:00.000Z"}\n',
+      '{"downloadCount":4,"lastUpdated":"2026-08-25T00:00:00.000Z","downloadsByIp":{"8.8.8.8":"2026-08-22T00:00:00.000Z","9.9.9.9":"2026-08-25T00:00:00.000Z"}}\n',
     );
-    fs.rmSync(
-      path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'),
-    );
+    fs.rmSync(path.join(live, 'wiki/tiddlers/comments/approved/old.china.tid'));
     fs.writeFileSync(
       path.join(live, 'wiki/tiddlers/ratings/new.china.tid'),
       'rating\n',
     );
 
-    run(shellExecutable(), [shellPath(syncScript)], {
-      env: {
-        ...process.env,
-        CPL_REPO_ROOT: shellPath(live),
-        CPL_SERVER_ID: 'china',
-        CPL_SYNC_REPO: shellPath(remote),
-        CPL_SYNC_BRANCH: 'master',
-      },
-    });
+    expect(
+      syncRuntimeData({
+        repoRoot: live,
+        serverId: 'china',
+        syncRepo: remote,
+        baseBranch: 'master',
+      }),
+    ).toBe('pushed');
 
     run('git', ['clone', '--branch', 'data-sync/china', remote, verify]);
     expect(
@@ -139,17 +117,13 @@ test('runtime data sync overlays only this server and never decreases stats', ()
         path.join(verify, 'wiki/tiddlers/download-stats/plugin.china.tid'),
         'utf8',
       ),
-    ).toBe(
-      '{"downloadCount":4,"lastUpdated":"2026-08-25T00:00:00.000Z"}\n',
-    );
+    ).toContain('"downloadCount":4');
     expect(
       fs.readFileSync(
         path.join(verify, 'wiki/tiddlers/download-stats/plugin.us.tid'),
         'utf8',
       ),
-    ).toBe(
-      '{"downloadCount":9,"lastUpdated":"2026-08-22T00:00:00.000Z"}\n',
-    );
+    ).toContain('"downloadCount":9');
     expect(
       fs.existsSync(path.join(verify, 'wiki/tiddlers/ratings/new.china.tid')),
     ).toBe(true);

--- a/tests/unit/sync-data-merge.test.js
+++ b/tests/unit/sync-data-merge.test.js
@@ -1,0 +1,175 @@
+const {
+  mergeDownloadStats,
+  parseStatsTiddler,
+  overlayServerTiddlers,
+  laterTimestamp,
+} = require('../../scripts/sync-data.ts');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const tid = (stats) =>
+  [
+    'title: $:/cpl/download-stats/plugin',
+    'plugin-title: $:/plugins/example',
+    'type: application/json',
+    '',
+    JSON.stringify(stats),
+  ].join('\n');
+
+describe('download stats merge', () => {
+  test('keeps the higher count and the newer lastUpdated', () => {
+    const merged = mergeDownloadStats(
+      {
+        downloadCount: 5,
+        lastUpdated: '2026-08-01T00:00:00.000Z',
+        downloadsByIp: { '1.1.1.1': '2026-08-01T00:00:00.000Z' },
+      },
+      {
+        downloadCount: 3,
+        lastUpdated: '2026-08-22T00:00:00.000Z',
+        downloadsByIp: {
+          '1.1.1.1': '2026-08-01T00:00:00.000Z',
+          '8.8.8.8': '2026-08-22T00:00:00.000Z',
+        },
+      },
+    );
+
+    expect(merged.downloadCount).toBe(5);
+    expect(merged.lastUpdated).toBe('2026-08-22T00:00:00.000Z');
+    expect(merged.downloadsByIp).toEqual({
+      '1.1.1.1': '2026-08-01T00:00:00.000Z',
+      '8.8.8.8': '2026-08-22T00:00:00.000Z',
+    });
+  });
+
+  test('unions IPs and never rewinds an IP timestamp', () => {
+    const merged = mergeDownloadStats(
+      {
+        downloadCount: 2,
+        lastUpdated: '2026-08-25T00:00:00.000Z',
+        downloadsByIp: { '9.9.9.9': '2026-08-25T00:00:00.000Z' },
+      },
+      {
+        downloadCount: 4,
+        lastUpdated: '2026-08-20T00:00:00.000Z',
+        downloadsByIp: { '8.8.8.8': '2026-08-20T00:00:00.000Z' },
+      },
+    );
+
+    expect(merged.downloadCount).toBe(4);
+    expect(merged.lastUpdated).toBe('2026-08-25T00:00:00.000Z');
+    expect(merged.downloadsByIp).toEqual({
+      '8.8.8.8': '2026-08-20T00:00:00.000Z',
+      '9.9.9.9': '2026-08-25T00:00:00.000Z',
+    });
+  });
+
+  test('laterTimestamp prefers the ISO-later value', () => {
+    expect(
+      laterTimestamp('2026-08-01T00:00:00.000Z', '2026-08-22T00:00:00.000Z'),
+    ).toBe('2026-08-22T00:00:00.000Z');
+  });
+
+  test('parseStatsTiddler reads JSON bodies', () => {
+    expect(
+      parseStatsTiddler(
+        tid({
+          downloadCount: 3,
+          lastUpdated: '2026-08-13T19:32:53.748Z',
+          downloadsByIp: { '1.1.1.1': '2026-08-13T19:32:53.748Z' },
+        }),
+      ),
+    ).toEqual({
+      downloadCount: 3,
+      lastUpdated: '2026-08-13T19:32:53.748Z',
+      downloadsByIp: { '1.1.1.1': '2026-08-13T19:32:53.748Z' },
+    });
+  });
+});
+
+describe('overlayServerTiddlers', () => {
+  test('merges this server stats and leaves the other mirror alone', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'cpl-overlay-'));
+    const source = path.join(root, 'source');
+    const destination = path.join(root, 'destination');
+    const statsDir = 'wiki/tiddlers/download-stats';
+
+    try {
+      fs.mkdirSync(path.join(source, statsDir), { recursive: true });
+      fs.mkdirSync(path.join(destination, statsDir), { recursive: true });
+
+      fs.writeFileSync(
+        path.join(source, statsDir, 'plugin.china.tid'),
+        tid({
+          downloadCount: 5,
+          lastUpdated: '2026-08-01T00:00:00.000Z',
+          downloadsByIp: { '1.1.1.1': '2026-08-01T00:00:00.000Z' },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(source, statsDir, 'plugin.us.tid'),
+        tid({
+          downloadCount: 1,
+          lastUpdated: '2026-08-02T00:00:00.000Z',
+          downloadsByIp: { '9.9.9.9': '2026-08-02T00:00:00.000Z' },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(destination, statsDir, 'plugin.china.tid'),
+        tid({
+          downloadCount: 3,
+          lastUpdated: '2026-08-22T00:00:00.000Z',
+          downloadsByIp: {
+            '1.1.1.1': '2026-08-01T00:00:00.000Z',
+            '8.8.8.8': '2026-08-22T00:00:00.000Z',
+          },
+        }),
+      );
+      fs.writeFileSync(
+        path.join(destination, statsDir, 'plugin.us.tid'),
+        tid({
+          downloadCount: 9,
+          lastUpdated: '2026-08-22T00:00:00.000Z',
+          downloadsByIp: { '8.8.8.8': '2026-08-22T00:00:00.000Z' },
+        }),
+      );
+
+      overlayServerTiddlers({
+        sourceRoot: source,
+        destinationRoot: destination,
+        serverId: 'china',
+      });
+
+      expect(
+        parseStatsTiddler(
+          fs.readFileSync(
+            path.join(destination, statsDir, 'plugin.china.tid'),
+            'utf8',
+          ),
+        ),
+      ).toEqual({
+        downloadCount: 5,
+        lastUpdated: '2026-08-22T00:00:00.000Z',
+        downloadsByIp: {
+          '1.1.1.1': '2026-08-01T00:00:00.000Z',
+          '8.8.8.8': '2026-08-22T00:00:00.000Z',
+        },
+      });
+      expect(
+        parseStatsTiddler(
+          fs.readFileSync(
+            path.join(destination, statsDir, 'plugin.us.tid'),
+            'utf8',
+          ),
+        ),
+      ).toEqual({
+        downloadCount: 9,
+        lastUpdated: '2026-08-22T00:00:00.000Z',
+        downloadsByIp: { '8.8.8.8': '2026-08-22T00:00:00.000Z' },
+      });
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,5 @@
       "cache": false
     }
   },
-  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in cache|data-sync/*) exit 0;; esac; if git rev-parse --verify --quiet HEAD^ >/dev/null && [ -z \"$(git diff --name-only HEAD^ HEAD | grep -vE '^wiki/tiddlers/(download-stats|comments|ratings|compatibility)/' || true)\" ]; then exit 0; fi; exit 1"
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in cache|data-sync/*) exit 0;; *) exit 1;; esac"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -8,5 +8,5 @@
       "cache": false
     }
   },
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"cache\" ]; then exit 0; else exit 1; fi"
+  "ignoreCommand": "case \"$VERCEL_GIT_COMMIT_REF\" in cache|data-sync/*) exit 0;; esac; if git rev-parse --verify --quiet HEAD^ >/dev/null && [ -z \"$(git diff --name-only HEAD^ HEAD | grep -vE '^wiki/tiddlers/(download-stats|comments|ratings|compatibility)/' || true)\" ]; then exit 0; fi; exit 1"
 }

--- a/wiki/tiddlers/Deployment.tid
+++ b/wiki/tiddlers/Deployment.tid
@@ -112,7 +112,7 @@ The sync process requires repository-scoped Git push credentials. In Kubernetes,
 CPL_SERVER_ID=china pnpm run sync-data
 ```
 
-`scripts/sync-data.sh` clones the latest `master` into a temporary worktree, overlays only the four runtime-data paths, commits changes to the stable `data-sync/{serverId}` branch, and force-updates that branch. It never switches or resets the live wiki worktree. `.github/workflows/data-sync-pr.yml` creates the Pull Request when one does not already exist.
+`scripts/sync-data.ts` clones the latest `master` into a temporary worktree, overlays only this mirror's `*.{serverId}.tid` files, merges download stats (max count / newest timestamp / union of IPs), commits to `data-sync/{serverId}`, and force-updates that branch. It never switches or resets the live wiki worktree. `.github/workflows/data-sync-pr.yml` creates the Pull Request when one does not already exist.
 
 Example cron (weekly, Monday 03:00):
 


### PR DESCRIPTION
## Summary
- 国内/海外同步只 overlay 本机 `*.{serverId}.tid`，不再整目录覆盖另一边的下载统计
- 下载数更小或 lastUpdated 更旧时跳过，避免 PVC/Forgejo 旧快照把 GitHub 数据改小改旧
- 数据-only PR / `data-sync/*` 分支跳过 CI、Vercel、GitHub Pages 和 Docker 构建

## Test plan
- [x] `tests/unit/data-sync.test.js`：过期 PVC 不开 PR；本机增量会提交；不改另一边的 `.us.tid`
- [ ] 合并后关闭 #270 / #271，不要把回退统计合进 master
- [ ] 下一轮 china/us data-sync 只应出现本机增量，不应再改小 downloadCount
