### PR TITLE
fix(data-sync): actually run overlay under Node 22 type stripping

### DIFF
--- a/scripts/sync-data.ts
+++ b/scripts/sync-data.ts
@@ -406,6 +406,14 @@ export const main = (): number => {
   }
 };
 
-if (typeof require !== 'undefined' && require.main === module) {
+const invokedAsCli = (): boolean => {
+  const entry = process.argv[1];
+  return Boolean(entry && path.basename(entry) === 'sync-data.ts');
+};
+
+// Node 22 `--experimental-strip-types` re-parses this file as ESM, so
+// `require.main === module` never fires and the sidecar would exit 0
+// without overlaying or pushing.
+if (invokedAsCli()) {
   process.exit(main());
 }

--- a/tests/unit/sync-data-cli.test.js
+++ b/tests/unit/sync-data-cli.test.js
@@ -1,0 +1,28 @@
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const SCRIPT = path.join(__dirname, '../../scripts/sync-data.ts');
+
+const runScript = env =>
+  spawnSync(process.execPath, ['--experimental-strip-types', SCRIPT], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+
+describe('sync-data CLI entrypoint', () => {
+  test('node type-stripping actually invokes main()', () => {
+    const result = runScript({
+      CPL_SERVER_ID: '',
+      CPL_REPO_ROOT: os.tmpdir(),
+    });
+
+    expect(result.status).toBe(1);
+    expect(`${result.stdout}\n${result.stderr}`).toMatch(
+      /CPL_SERVER_ID is required/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Sidecar runs `node --experimental-strip-types scripts/sync-data.ts`. Node 22 reparses the file as ESM, so `require.main === module` never fires.
- The weekly job then exited 0 after a module-type warning, without cloning GitHub or pushing `data-sync/*`.
- Invoke `main()` when argv points at `sync-data.ts`, and add a regression test that the CLI path returns "CPL_SERVER_ID is required".

## Test plan
- [x] `npx jest tests/unit/sync-data-cli.test.js tests/unit/sync-data-merge.test.js tests/unit/data-sync.test.js`
- [ ] After merge, git-sync on both CPL pods reaches this commit
- [ ] data-sync logs `[sync-data] No runtime data changes` or `Updated data-sync/...` instead of only the MODULE_TYPELESS warning