### PR TITLE
Remove SFL plugin from libraries list

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -62,9 +62,5 @@
   {
     "name": "Dyp",
     "uri": "https://dyp1121054136.github.io/dyp-plugins-library/library/index.html"
-  },
-  {
-    "name": "SFL",
-    "uri": "https://plugins.theophile.dev"
   }
 ]


### PR DESCRIPTION
Removed since the library does not follow the standard tiddlywiki plugin library model. Might add later if I figure out a way to make it compatible with Tiddlywiki-CPL